### PR TITLE
fix: rename ItemTemplate → itemTemplate for consistency

### DIFF
--- a/examples/stac_gallery/assets/json/dynamic_list_view_example.json
+++ b/examples/stac_gallery/assets/json/dynamic_list_view_example.json
@@ -16,7 +16,7 @@
     "targetPath": "users",
     "template": {
       "type": "listView",
-      "ItemTemplate": {
+      "itemTemplate": {
         "type": "listTile",
         "title": {
           "type": "text",

--- a/packages/stac/lib/src/parsers/widgets/stac_dynamic_view/stac_dynamic_view_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_dynamic_view/stac_dynamic_view_parser.dart
@@ -104,10 +104,10 @@ class StacDynamicViewParser extends StacParser<StacDynamicView> {
     Map<String, dynamic> result = {};
 
     if (data is List) {
-      // Check if the template contains an ItemTemplate key
-      if (template.containsKey('ItemTemplate')) {
-        // Create a list of widgets using the ItemTemplate
-        final itemTemplate = template['ItemTemplate'] as Map<String, dynamic>;
+      // Check if the template contains an itemTemplate key
+      if (template.containsKey('itemTemplate')) {
+        // Create a list of widgets using the itemTemplate
+        final itemTemplate = template['itemTemplate'] as Map<String, dynamic>;
 
         // Process each item in the list
         final items = <Map<String, dynamic>>[];
@@ -121,7 +121,7 @@ class StacDynamicViewParser extends StacParser<StacDynamicView> {
 
         // Create the result with the processed items
         result = Map<String, dynamic>.from(template);
-        result.remove('ItemTemplate'); // Remove the template
+        result.remove('itemTemplate'); // Remove the template
 
         // If the template doesn't have a children key, create it
         if (!result.containsKey('children')) {
@@ -137,7 +137,7 @@ class StacDynamicViewParser extends StacParser<StacDynamicView> {
           result['children'] = items;
         }
       } else {
-        // If no ItemTemplate is found, pass through the template
+        // If no itemTemplate is found, pass through the template
         result = template;
       }
     } else if (data is Map) {

--- a/website/docs/widgets/dynamic_view.md
+++ b/website/docs/widgets/dynamic_view.md
@@ -10,7 +10,7 @@ The `dynamicView` widget allows you to fetch data from an API and render it usin
 - Apply data to templates with placeholder syntax
 - Extract nested data using dot notation
 - Handle both single objects and lists of data
-- Render lists of items using the ItemTemplate feature
+- Render lists of items using the itemTemplate feature
 
 ## Properties
 
@@ -19,7 +19,7 @@ The `dynamicView` widget allows you to fetch data from an API and render it usin
 | request     | `StacNetworkRequest`  | Yes      | API request configuration (url, method, headers, etc.)     |
 | template    | `Map<String, dynamic>` | Yes      | Template to render with data from the API response        |
 | targetPath  | `String`              | No       | Path to extract specific data from the API response        |
-| ItemTemplate | `Map<String, dynamic>` | No       | Template to render each item in a list of items from the API response |
+| itemTemplate | `Map<String, dynamic>` | No       | Template to render each item in a list of items from the API response |
 
 ## Basic Usage
 
@@ -74,10 +74,10 @@ Use double curly braces `{{placeholder}}` to insert data from the API response i
 }
 ```
 
-### List Example with ItemTemplate
+### List Example with itemTemplate
 
 
-When the API returns a list of items, use the `ItemTemplate` property to define how each item should be rendered:
+When the API returns a list of items, use the `itemTemplate` property to define how each item should be rendered:
 
 ```json
 {
@@ -89,7 +89,7 @@ When the API returns a list of items, use the `ItemTemplate` property to define 
   "targetPath": "users",
   "template": {
     "type": "listView",
-    "ItemTemplate": {
+    "itemTemplate": {
       "type": "listTile",
       "title": {
         "type": "text",
@@ -152,7 +152,7 @@ Add custom headers to your API requests:
 ## Best Practices
 
 1. Use `targetPath` to extract only the data you need from complex API responses
-2. For list data, always use the `ItemTemplate` property to define how each item should be rendered
+2. For list data, always use the `itemTemplate` property to define how each item should be rendered
 3. Keep templates modular and reusable when possible
 4. Use appropriate error handling in your UI design for cases when the API request fails
 


### PR DESCRIPTION
## Description

Renamed all occurrences of `ItemTemplate` to `itemTemplate` for consistency with lower camelCase naming convention.

This includes:
- Parser logic
- JSON example files
- Documentation

## Related Issues

Closes #230 

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

