### PR TITLE
feat: add `normal` and `bold` to `StacFontWeight`

### DIFF
--- a/packages/stac/lib/src/parsers/widgets/stac_font_weight/stac_font_weight.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_font_weight/stac_font_weight.dart
@@ -9,7 +9,9 @@ enum StacFontWeight {
   w600,
   w700,
   w800,
-  w900;
+  w900,
+  normal,
+  bold;
 
   FontWeight get value {
     switch (this) {
@@ -39,6 +41,10 @@ enum StacFontWeight {
 
       case StacFontWeight.w900:
         return FontWeight.w900;
+      case StacFontWeight.normal:
+        return FontWeight.normal;
+      case StacFontWeight.bold:
+        return FontWeight.bold;
     }
   }
 }

--- a/packages/stac/lib/src/parsers/widgets/stac_text/stac_text.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_text/stac_text.dart
@@ -6,6 +6,7 @@ import 'package:stac/src/parsers/widgets/stac_text_style/stac_text_style.dart';
 export 'stac_text_parser.dart';
 
 part 'stac_text.freezed.dart';
+
 part 'stac_text.g.dart';
 
 @freezed

--- a/packages/stac/lib/src/parsers/widgets/stac_text/stac_text.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_text/stac_text.dart
@@ -6,7 +6,6 @@ import 'package:stac/src/parsers/widgets/stac_text_style/stac_text_style.dart';
 export 'stac_text_parser.dart';
 
 part 'stac_text.freezed.dart';
-
 part 'stac_text.g.dart';
 
 @freezed

--- a/packages/stac/lib/src/parsers/widgets/stac_text_style/stac_text_style.g.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_text_style/stac_text_style.g.dart
@@ -61,6 +61,8 @@ const _$StacFontWeightEnumMap = {
   StacFontWeight.w700: 'w700',
   StacFontWeight.w800: 'w800',
   StacFontWeight.w900: 'w900',
+  StacFontWeight.normal: 'normal',
+  StacFontWeight.bold: 'bold',
 };
 
 const _$FontStyleEnumMap = {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Introduced `normal` and `bold` font weight options to the `StacFontWeight` enum.
- These additions allow for more common and intuitive font weight specifications, aligning with standard CSS and design practices.
- The generated code for `StacTextStyle` has also been updated to include these new enum values.

**Note**: 

```
  /// The default font weight.
  static const FontWeight normal = w400;

  /// A commonly used font weight that is heavier than normal.
  static const FontWeight bold = w700;
```

## Related Issues

<!--- List the related issues to this PR -->
Closes #259


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
