### PR TITLE
refactor: migrate Theme classes to ThemeData classes 

### DIFF
--- a/packages/stac/lib/src/parsers/stac_card_theme_data/stac_card_theme_data.dart
+++ b/packages/stac/lib/src/parsers/stac_card_theme_data/stac_card_theme_data.dart
@@ -24,8 +24,8 @@ class StacCardThemeData with _$StacCardThemeData {
 }
 
 extension StacCardThemeDataParser on StacCardThemeData {
-  CardTheme? parse(BuildContext context) {
-    return CardTheme(
+  CardThemeData? parse(BuildContext context) {
+    return CardThemeData(
       clipBehavior: clipBehavior,
       color: color.toColor(context),
       shadowColor: shadowColor.toColor(context),

--- a/packages/stac/lib/src/parsers/stac_dialog_theme/stac_dialog_theme.dart
+++ b/packages/stac/lib/src/parsers/stac_dialog_theme/stac_dialog_theme.dart
@@ -29,8 +29,8 @@ class StacDialogTheme with _$StacDialogTheme {
 }
 
 extension StacDialogThemeParser on StacDialogTheme {
-  DialogTheme? parse(BuildContext context) {
-    return DialogTheme(
+  DialogThemeData? parse(BuildContext context) {
+    return DialogThemeData(
       backgroundColor: backgroundColor.toColor(context),
       elevation: elevation,
       shadowColor: shadowColor.toColor(context),

--- a/packages/stac/lib/src/parsers/stac_tab_bar_theme_data/stac_tab_bar_theme_data.dart
+++ b/packages/stac/lib/src/parsers/stac_tab_bar_theme_data/stac_tab_bar_theme_data.dart
@@ -28,8 +28,8 @@ class StacTabBarThemeData with _$StacTabBarThemeData {
 }
 
 extension StacTabBarThemeDataParser on StacTabBarThemeData {
-  TabBarTheme? parse(BuildContext context) {
-    return TabBarTheme(
+  TabBarThemeData? parse(BuildContext context) {
+    return TabBarThemeData(
       indicator: indicator.parse(context),
       indicatorColor: indicatorColor.toColor(context),
       indicatorSize: indicatorSize,


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

In order to be compatible with Flutter 3.32, this PR migrates `dialogTheme`, `tabBarTheme`, and `cardTheme` to `DialogThemeData`, `TabBarThemeData`, and `CardThemeData`, respectively. 

## Related Issues

<!--- List the related issues to this PR -->
Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
