### PR TITLE
Add StacScreen annotation and annotations barrel; re-export in barrels

### DIFF
--- a/packages/stac_core/lib/annotations/annotations.dart
+++ b/packages/stac_core/lib/annotations/annotations.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'stac_screen.dart';

--- a/packages/stac_core/lib/annotations/stac_screen.dart
+++ b/packages/stac_core/lib/annotations/stac_screen.dart
@@ -1,0 +1,20 @@
+/// Annotation to mark methods that return StacWidget instances.
+///
+/// This annotation is used to identify screen-level widgets in the Stac framework.
+/// Methods that return StacWidget should be annotated with this to indicate
+/// they represent screen definitions.
+///
+/// Example usage:
+/// ```dart
+/// @StacScreen(screenName: 'home')
+/// StacWidget buildHomeScreen() {
+///   return StacWidget(jsonData: {'type': 'scaffold', 'body': '...'});
+/// }
+/// ```
+class StacScreen {
+  /// Creates a [StacScreen] annotation with the given screen name.
+  const StacScreen({required this.screenName});
+
+  /// The name identifier for this screen.
+  final String screenName;
+}

--- a/packages/stac_core/lib/core/core.dart
+++ b/packages/stac_core/lib/core/core.dart
@@ -2,3 +2,4 @@ library;
 
 export 'stac_action.dart';
 export 'stac_widget.dart';
+export '../annotations/annotations.dart';

--- a/packages/stac_core/lib/stac_core.dart
+++ b/packages/stac_core/lib/stac_core.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'actions/actions.dart';
+export 'annotations/annotations.dart';
 export 'core/core.dart';
 export 'foundation/foundation.dart';
 export 'widgets/widgets.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Create new `packages/stac_core/lib/annotations/` directory
- Add `stac_screen.dart` with @StacScreen annotation class
- Add `annotations.dart` export file for the annotations package
- Update `core.dart` to export annotations package

### Breaking Changes:
- Methods returning StacWidget must now be annotated with @StacScreen to be processed
- Previously unannotated StacWidget-returning methods will no longer be automatically processed

### Usage:
```dart
import 'package:stac_core/stac_core.dart';

@StacScreen('home')
StacWidget buildHomeScreen() => StacWidget();
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a @StacScreen annotation (const StacScreen(screenName: ...)) for marking screen-producing methods.
  * Annotation is exported from the annotations module and re-exported via core and top-level package so it’s available from main imports.
  * Simplified imports for users by exposing the annotation through primary package entry points.
  * Includes documentation and a usage example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->