### PR TITLE
docs: upgrade freezed class to match freezed version 3.*

### DIFF
--- a/bricks/stac_parser/__brick__/{{#snakecase}}stac_{{name}}{{/snakecase}}/{{#snakecase}}stac_{{name}}{{/snakecase}}.dart
+++ b/bricks/stac_parser/__brick__/{{#snakecase}}stac_{{name}}{{/snakecase}}/{{#snakecase}}stac_{{name}}{{/snakecase}}.dart
@@ -4,7 +4,7 @@ part '{{#snakeCase}}stac_{{name}}{{/snakeCase}}.freezed.dart';
 part '{{#snakeCase}}stac_{{name}}{{/snakeCase}}.g.dart';
 
 @freezed
-class Stac{{#pascalCase}}{{name}}{{/pascalCase}} with _$Stac{{#pascalCase}}{{name}}{{/pascalCase}} {
+abstract class Stac{{#pascalCase}}{{name}}{{/pascalCase}} with _$Stac{{#pascalCase}}{{name}}{{/pascalCase}} {
   const factory Stac{{#pascalCase}}{{name}}{{/pascalCase}}() = _Stac{{#pascalCase}}{{name}}{{/pascalCase}};
 
   factory Stac{{#pascalCase}}{{name}}{{/pascalCase}}.fromJson(Map<String, dynamic> json) => _$Stac{{#pascalCase}}{{name}}{{/pascalCase}}FromJson(json);

--- a/website/docs/concepts/action_parsers.md
+++ b/website/docs/concepts/action_parsers.md
@@ -36,7 +36,7 @@ For this JSON Structure, we can create a data class to represent the custom acti
 
 ```dart
 @freezed
-class PrintAction with _$PrintAction {
+abstract class PrintAction with _$PrintAction {
   const factory PrintAction({
     required String message,
   }) = _PrintAction;

--- a/website/docs/concepts/parsers.md
+++ b/website/docs/concepts/parsers.md
@@ -45,7 +45,7 @@ Here we are using the freezed package to create the data class. But you can use 
 
 ```dart
 @freezed
-class CustomButton with _$CustomButton {
+abstract class CustomButton with _$CustomButton {
   const factory CustomButton({
     required String text,
     required String color,


### PR DESCRIPTION

## Description

Upgrade the freezed class documentation to add `abstact` before starting of class definition to support freezed versions 3.*
I have also changed brick definition for mason.

## Related Issues

Closes #352 

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Converted data classes (e.g., Stac{name}, PrintAction, CustomButton) to abstract classes while retaining factory constructors and JSON deserialization. Instances are now created via factories; direct instantiation is no longer available.
- Documentation
  - Updated action_parsers and parsers guides to reflect abstract class declarations and factory-based instantiation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->