### PR TITLE
docs: update stac readme links

### DIFF
--- a/packages/stac/README.md
+++ b/packages/stac/README.md
@@ -45,20 +45,20 @@ This approach separates your app's presentation layer from its business logic, e
 ## Documentation
 
 - 📚 **[Full Documentation](https://docs.stac.dev/)** – Complete guides and API reference
-- 🚀 **[Quick Start](https://docs.stac.dev/get_started/quick_start)** – Get up and running in minutes
+- 🚀 **[Quick Start](https://docs.stac.dev/quickstart)** – Get up and running in minutes
 - 🛠️ **[Stac CLI](https://docs.stac.dev/cli)** – Command-line tools for development
 - 🎛️ **[Stac Console](https://console.stac.dev/)** – Web interface for managing your app
-- 🤝 **[Contributing](https://github.com/StacDev/stac/blob/main/CONTRIBUTING.md)** – Help build Stac
+- 🤝 **[Contributing](../../CONTRIBUTING.md)** – Help build Stac
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/StacDev/stac/blob/dev/LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](/LICENSE) file for details.
 
 ## Join our community
 
 - 💬 **[Discord](https://discord.com/invite/vTGsVRK86V)** – Chat with the community and get help
 - 🐙 **[GitHub](https://github.com/StacDev/stac)** – Report issues and contribute
-- 🐦 **[Twitter](https://twitter.com/stacdev)** – Follow us for updates
+- 🐦 **[X](https://x.com/stac_dev)** – Follow us for updates
 
 ---
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

  - replace the outdated Quick Start link with the working docs URL
  - switch internal CONTRIBUTING and LICENSE links to repo-relative paths
  - update the social link label to X while pointing at the new profile URL

## Related Issues


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start link to the new docs location to prevent broken or outdated links.
  * Adjusted Contributing link to a repository-relative path for consistent in-repo navigation.
  * Updated License reference to point to the local LICENSE file for clearer licensing information.
  * Renamed social link from Twitter to X and updated the handle and URL accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->