### PR TITLE
feat(networkWidget): added loader and error widget support to networkwidget

### DIFF
--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1440,5 +1440,27 @@
         "assetPath": "assets/json/backdrop_filter_example.json"
       }
     }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
+      "icon": "cloud_download"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Network Widget"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "Fetch data from network with loading and error states"
+    },
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/network_widget_example.json"
+      }
+    }
   }
 ]

--- a/examples/stac_gallery/assets/json/network_widget_example.json
+++ b/examples/stac_gallery/assets/json/network_widget_example.json
@@ -1,0 +1,74 @@
+{
+  "type": "scaffold",
+  "appBar": {
+    "type": "appBar",
+    "title": {
+      "type": "text",
+      "data": "Network Widget Example"
+    }
+  },
+  "body": {
+    "type": "networkWidget",
+    "request": {
+      "actionType": "networkRequest",
+      "url": "https://httpbin.org/delay/2",
+      "method": "get"
+    },
+    "loadingWidget": {
+      "type": "center",
+      "child": {
+        "type": "column",
+        "mainAxisAlignment": "center",
+        "children": [
+          {
+            "type": "circularProgressIndicator"
+          },
+          {
+            "type": "sizedBox",
+            "height": 16.0
+          },
+          {
+            "type": "text",
+            "data": "Loading..."
+          }
+        ]
+      }
+    },
+    "errorWidget": {
+      "type": "center",
+      "child": {
+        "type": "column",
+        "mainAxisAlignment": "center",
+        "children": [
+          {
+            "type": "icon",
+            "icon": "error",
+            "size": 48.0,
+            "color": "#E53935"
+          },
+          {
+            "type": "sizedBox",
+            "height": 16.0
+          },
+          {
+            "type": "text",
+            "data": "Failed to load",
+            "style": {
+              "fontSize": 18.0,
+              "fontWeight": "bold"
+            }
+          },
+          {
+            "type": "sizedBox",
+            "height": 8.0
+          },
+          {
+            "type": "text",
+            "data": "Please check your connection and try again"
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
@@ -15,6 +15,23 @@ class StacNetworkWidgetParser extends StacParser<StacNetworkWidget> {
 
   @override
   Widget parse(BuildContext context, StacNetworkWidget model) {
-    return Stac.fromNetwork(context: context, request: model.request);
+    return Stac.fromNetwork(
+      context: context,
+      request: model.request,
+      loadingWidget: model.loadingWidget == null
+          ? null
+          : (ctx) => StacService.fromStacWidget(
+                widget: model.loadingWidget!,
+                context: ctx,
+              ) ??
+              const SizedBox(),
+      errorWidget: model.errorWidget == null
+          ? null
+          : (ctx, error) => StacService.fromStacWidget(
+                widget: model.errorWidget!,
+                context: ctx,
+              ) ??
+              const SizedBox(),
+    );
   }
 }

--- a/packages/stac_core/lib/widgets/network_widget/stac_network_widget.dart
+++ b/packages/stac_core/lib/widgets/network_widget/stac_network_widget.dart
@@ -38,10 +38,20 @@ part 'stac_network_widget.g.dart';
 @JsonSerializable()
 class StacNetworkWidget extends StacWidget {
   /// Creates a [StacNetworkWidget].
-  const StacNetworkWidget({required this.request});
+  const StacNetworkWidget({
+    required this.request,
+    this.loadingWidget,
+    this.errorWidget,
+  });
 
   /// The network request to execute.
   final StacNetworkRequest request;
+
+  /// Optional widget to render while the network request is in progress.
+  final StacWidget? loadingWidget;
+
+  /// Optional widget to render if the network request fails.
+  final StacWidget? errorWidget;
 
   /// Widget type identifier.
   @override

--- a/packages/stac_core/lib/widgets/network_widget/stac_network_widget.g.dart
+++ b/packages/stac_core/lib/widgets/network_widget/stac_network_widget.g.dart
@@ -11,10 +11,18 @@ StacNetworkWidget _$StacNetworkWidgetFromJson(Map<String, dynamic> json) =>
       request: StacNetworkRequest.fromJson(
         json['request'] as Map<String, dynamic>,
       ),
+      loadingWidget: json['loadingWidget'] == null
+          ? null
+          : StacWidget.fromJson(json['loadingWidget'] as Map<String, dynamic>),
+      errorWidget: json['errorWidget'] == null
+          ? null
+          : StacWidget.fromJson(json['errorWidget'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$StacNetworkWidgetToJson(StacNetworkWidget instance) =>
     <String, dynamic>{
       'request': instance.request.toJson(),
+      'loadingWidget': instance.loadingWidget?.toJson(),
+      'errorWidget': instance.errorWidget?.toJson(),
       'type': instance.type,
     };

--- a/packages/stac_core/test/widgets/network_widget/stac_network_widget_test.dart
+++ b/packages/stac_core/test/widgets/network_widget/stac_network_widget_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stac_core/stac_core.dart';
+
+void main() {
+  group('StacNetworkWidget', () {
+    test('should create from JSON with loadingWidget and errorWidget', () {
+      // Arrange
+      const json = {
+        'type': 'networkWidget',
+        'request': {
+          'actionType': 'networkRequest',
+          'url': 'https://example.com/data',
+          'method': 'get'
+        },
+        'loadingWidget': {
+          'type': 'text',
+          'data': 'Loading...'
+        },
+        'errorWidget': {
+          'type': 'text',
+          'data': 'Error occurred'
+        }
+      };
+
+      // Act
+      final widget = StacNetworkWidget.fromJson(json);
+
+      // Assert
+      expect(widget.request.url, equals('https://example.com/data'));
+      expect(widget.loadingWidget, isNotNull);
+      expect(widget.errorWidget, isNotNull);
+    });
+
+    test('should create from JSON without optional widgets', () {
+      // Arrange
+      const json = {
+        'type': 'networkWidget',
+        'request': {
+          'actionType': 'networkRequest',
+          'url': 'https://example.com/data',
+          'method': 'get'
+        }
+      };
+
+      // Act
+      final widget = StacNetworkWidget.fromJson(json);
+
+      // Assert
+      expect(widget.request.url, equals('https://example.com/data'));
+      expect(widget.loadingWidget, isNull);
+      expect(widget.errorWidget, isNull);
+    });
+
+    test('should serialize to JSON with loadingWidget and errorWidget', () {
+      // Arrange
+      final widget = StacNetworkWidget(
+        request: StacNetworkRequest(
+          url: 'https://example.com/data',
+          method: 'get',
+        ),
+        loadingWidget: StacWidget.fromJson({'type': 'text', 'data': 'Loading...'}),
+        errorWidget: StacWidget.fromJson({'type': 'text', 'data': 'Error'}),
+      );
+
+      // Act
+      final json = widget.toJson();
+
+      // Assert
+      expect(json['request'], isNotNull);
+      expect(json['loadingWidget'], isNotNull);
+      expect(json['errorWidget'], isNotNull);
+      expect(json['loadingWidget']['data'], equals('Loading...'));
+      expect(json['errorWidget']['data'], equals('Error'));
+    });
+
+    test('should serialize to JSON without optional widgets', () {
+      // Arrange
+      final widget = StacNetworkWidget(
+        request: StacNetworkRequest(
+          url: 'https://example.com/data',
+          method: 'get',
+        ),
+      );
+
+      // Act
+      final json = widget.toJson();
+
+      // Assert
+      expect(json['request'], isNotNull);
+      expect(json['loadingWidget'], isNull);
+      expect(json['errorWidget'], isNull);
+    });
+  });
+}
+


### PR DESCRIPTION
Network Widget

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Added loadingWidget and errorWidget fields to StacNetworkWidget model
- Updated JSON serialization to support the new fields
- Updated parser to pass these widgets to the network request
<!--- Describe your changes in detail -->

## Related Issues

<!--- List the related issues to this PR -->
Closes #243 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Stac Network Widget" example to the gallery demonstrating network request handling with configurable UI states.
  * Enhanced network widget to support custom loading and error UI states for better user feedback during network operations.

* **Tests**
  * Added comprehensive tests for network widget serialization and deserialization with optional state widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->