### PR TITLE
feat: add loading and error widget support for StacNetworkWidget

### DIFF
--- a/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:stac/src/framework/framework.dart';
 import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac_core/stac_core.dart';
@@ -20,8 +20,10 @@ class StacNetworkWidgetParser extends StacParser<StacNetworkWidget> {
       context: context,
       request: model.request,
       loadingWidget: model.loadingWidget != null
-          ? (context) => model.loadingWidget!.parse(context) ?? const SizedBox()
-          : null,
+          ? (context) =>
+                model.loadingWidget!.parse(context) ??
+                const Center(child: CircularProgressIndicator())
+          : (context) => const Center(child: CircularProgressIndicator()),
       errorWidget: model.errorWidget != null
           ? (context, error) =>
                 model.errorWidget!.parse(context) ?? const SizedBox()

--- a/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:stac/src/framework/framework.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac_core/stac_core.dart';
 import 'package:stac_framework/stac_framework.dart';
 
@@ -15,6 +16,16 @@ class StacNetworkWidgetParser extends StacParser<StacNetworkWidget> {
 
   @override
   Widget parse(BuildContext context, StacNetworkWidget model) {
-    return Stac.fromNetwork(context: context, request: model.request);
+    return Stac.fromNetwork(
+      context: context,
+      request: model.request,
+      loadingWidget: model.loadingWidget != null
+          ? (context) => model.loadingWidget!.parse(context) ?? const SizedBox()
+          : null,
+      errorWidget: model.errorWidget != null
+          ? (context, error) =>
+                model.errorWidget!.parse(context) ?? const SizedBox()
+          : null,
+    );
   }
 }

--- a/packages/stac_core/lib/widgets/network_widget/stac_network_widget.dart
+++ b/packages/stac_core/lib/widgets/network_widget/stac_network_widget.dart
@@ -8,7 +8,8 @@ part 'stac_network_widget.g.dart';
 /// A Stac model representing a network-driven widget.
 ///
 /// This widget triggers a [StacNetworkRequest] to fetch a Stac UI JSON from a
-/// URL and renders it.
+/// URL and renders it. Optionally, you can provide custom loading and error
+/// widgets to display during the network request lifecycle.
 ///
 /// {@tool snippet}
 /// Dart Example:
@@ -17,6 +18,12 @@ part 'stac_network_widget.g.dart';
 ///   request: StacNetworkRequest(
 ///     url: 'https://example.com/data',
 ///     method: 'get',
+///   ),
+///   loadingWidget: StacCenter(
+///     child: StacCircularProgressIndicator(),
+///   ),
+///   errorWidget: StacCenter(
+///     child: StacText(data: 'Failed to load'),
 ///   ),
 /// )
 /// ```
@@ -31,6 +38,19 @@ part 'stac_network_widget.g.dart';
 ///     "actionType": "networkRequest",
 ///     "url": "https://example.com/data",
 ///     "method": "get"
+///   },
+///   "loadingWidget": {
+///     "type": "center",
+///     "child": {
+///       "type": "circularProgressIndicator"
+///     }
+///   },
+///   "errorWidget": {
+///     "type": "center",
+///     "child": {
+///       "type": "text",
+///       "data": "Failed to load"
+///     }
 ///   }
 /// }
 /// ```
@@ -38,10 +58,30 @@ part 'stac_network_widget.g.dart';
 @JsonSerializable()
 class StacNetworkWidget extends StacWidget {
   /// Creates a [StacNetworkWidget].
-  const StacNetworkWidget({required this.request});
+  ///
+  /// The [request] parameter is required and defines the network request
+  /// to execute. The [loadingWidget] and [errorWidget] parameters are
+  /// optional and allow you to customize the loading and error states.
+  const StacNetworkWidget({
+    required this.request,
+    this.loadingWidget,
+    this.errorWidget,
+  });
 
   /// The network request to execute.
+  ///
+  /// This defines the URL, method, headers, and body for the network request.
   final StacNetworkRequest request;
+
+  /// Optional widget to display while the network request is in progress.
+  ///
+  /// If not provided, a default loading indicator is shown.
+  final StacWidget? loadingWidget;
+
+  /// Optional widget to display when the network request fails.
+  ///
+  /// If not provided, an empty [SizedBox] is shown on error.
+  final StacWidget? errorWidget;
 
   /// Widget type identifier.
   @override

--- a/packages/stac_core/lib/widgets/network_widget/stac_network_widget.g.dart
+++ b/packages/stac_core/lib/widgets/network_widget/stac_network_widget.g.dart
@@ -11,10 +11,18 @@ StacNetworkWidget _$StacNetworkWidgetFromJson(Map<String, dynamic> json) =>
       request: StacNetworkRequest.fromJson(
         json['request'] as Map<String, dynamic>,
       ),
+      loadingWidget: json['loadingWidget'] == null
+          ? null
+          : StacWidget.fromJson(json['loadingWidget'] as Map<String, dynamic>),
+      errorWidget: json['errorWidget'] == null
+          ? null
+          : StacWidget.fromJson(json['errorWidget'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$StacNetworkWidgetToJson(StacNetworkWidget instance) =>
     <String, dynamic>{
       'request': instance.request.toJson(),
+      'loadingWidget': instance.loadingWidget?.toJson(),
+      'errorWidget': instance.errorWidget?.toJson(),
       'type': instance.type,
     };


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR adds support for custom loading and error widgets in the `StacNetworkWidget`. Users can now provide optional `loadingWidget` and `errorWidget` properties that will be displayed during the network request lifecycle.

**Changes:**
- Added `loadingWidget` and `errorWidget` as optional `StacWidget?` fields to `StacNetworkWidget`
- Updated `StacNetworkWidgetParser` to parse these widgets and pass them to `Stac.fromNetwork` as builder functions
- Updated documentation with Dart and JSON examples showing how to use the new features
- Generated JSON serialization code for the new fields

**Example Usage:**
```dart
StacNetworkWidget(
  request: StacNetworkRequest(
    url: 'https://example.com/data',
    method: 'get',
  ),
  loadingWidget: StacCenter(
    child: StacCircularProgressIndicator(),
  ),
  errorWidget: StacCenter(
    child: StacText(data: 'Failed to load'),
  ),
)
```
```json
{
  "type": "networkWidget",
  "request": {
    "actionType": "networkRequest",
    "url": "https://example.com/data",
    "method": "get"
  },
  "loadingWidget": {
    "type": "center",
    "child": {
      "type": "circularProgressIndicator"
    }
  },
  "errorWidget": {
    "type": "center",
    "child": {
      "type": "text",
      "data": "Failed to load"
    }
  }
}
```
## Related Issues

Closes #243

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network requests now support optional custom loading and error widgets. You can supply custom UI for loading and error states (or rely on sensible defaults), and configure them via the widget JSON. Documentation and examples for these optional widgets have been added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->