### PR TITLE
feat: add SelectableText widget and parser with documentation and exa…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,11 +133,11 @@
                         "pages": [
                             "widgets/custom_scroll_view",
                             "widgets/grid_view",
+                            "widgets/selectable_text",
                             "widgets/table",
                             "widgets/table_cell",
                             "widgets/table_row",
                             "widgets/text",
-                            "widgets/selectable_text",
                             "widgets/vertical_divider"
                         ]
                     }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -137,6 +137,7 @@
                             "widgets/table_cell",
                             "widgets/table_row",
                             "widgets/text",
+                            "widgets/selectable_text",
                             "widgets/vertical_divider"
                         ]
                     }

--- a/docs/widgets/selectable_text.mdx
+++ b/docs/widgets/selectable_text.mdx
@@ -15,7 +15,8 @@ To know more about the SelectableText widget in Flutter, refer to the [official 
 | style                      | `StacTextStyle?`     | The style to apply to the text.                   |
 | textAlign                  | `TextAlign?`         | The alignment of the text.                        |
 | textDirection              | `TextDirection?`     | The direction of the text.                        |
-| textScaleFactor            | `double?`            | The number of font pixels for each logical pixel. |
+| textScaleFactor            | `double?`            | **Deprecated.** Use `textScaler` instead.         |
+| textScaler                 | `double?`            | The font scaling strategy to use.                 |
 | showCursor                 | `bool?`              | Whether to show the cursor.                       |
 | autofocus                  | `bool?`              | Whether to autofocus the widget.                  |
 | minLines                   | `int?`               | The minimum number of lines to display.           |
@@ -29,6 +30,10 @@ To know more about the SelectableText widget in Flutter, refer to the [official 
 | semanticsLabel             | `String?`            | The semantics label for the text.                 |
 | textWidthBasis             | `TextWidthBasis?`    | The width basis for the text.                     |
 | selectionColor             | `String?`            | The color of the text selection.                  |
+
+> [!NOTE] 
+> `textScaleFactor` is deprecated. Use `textScaler` instead.
+> Example migration: `textScaler: 1.5` corresponds to `TextScaler.linear(1.5)`.
 
 ## Example JSON
 

--- a/docs/widgets/selectable_text.mdx
+++ b/docs/widgets/selectable_text.mdx
@@ -1,0 +1,46 @@
+---
+title: "SelectableText"
+description: "Documentation for SelectableText"
+---
+
+Stac SelectableText allows you to build the Flutter SelectableText widget using JSON.
+To know more about the SelectableText widget in Flutter, refer to the [official documentation](https://api.flutter.dev/flutter/material/SelectableText-class.html).
+
+## Properties
+
+| Property                   | Type                 | Description                                       |
+|----------------------------|----------------------|---------------------------------------------------|
+| data                       | `String`             | The text to display.                              |
+| children                   | `List<StacTextSpan>` | The list of text spans to display.                |
+| style                      | `StacTextStyle?`     | The style to apply to the text.                   |
+| textAlign                  | `TextAlign?`         | The alignment of the text.                        |
+| textDirection              | `TextDirection?`     | The direction of the text.                        |
+| textScaleFactor            | `double?`            | The number of font pixels for each logical pixel. |
+| showCursor                 | `bool?`              | Whether to show the cursor.                       |
+| autofocus                  | `bool?`              | Whether to autofocus the widget.                  |
+| minLines                   | `int?`               | The minimum number of lines to display.           |
+| maxLines                   | `int?`               | The maximum number of lines to display.           |
+| cursorWidth                | `double?`            | The width of the cursor.                          |
+| cursorHeight               | `double?`            | The height of the cursor.                         |
+| cursorRadius               | `double?`            | The radius of the cursor.                         |
+| cursorColor                | `String?`            | The color of the cursor.                          |
+| enableInteractiveSelection | `bool?`              | Whether to enable interactive selection.          |
+| onTap                      | `StacAction?`        | The action to perform when the text is tapped.    |
+| semanticsLabel             | `String?`            | The semantics label for the text.                 |
+| textWidthBasis             | `TextWidthBasis?`    | The width basis for the text.                     |
+| selectionColor             | `String?`            | The color of the text selection.                  |
+
+## Example JSON
+
+```json
+{
+  "type": "selectableText",
+  "data": "This is a selectable text",
+  "style": {
+    "fontSize": 18,
+    "fontWeight": "w600"
+  },
+  "showCursor": true,
+  "cursorColor": "#FF0000"
+}
+```

--- a/examples/counter_example/pubspec.yaml
+++ b/examples/counter_example/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  stac: ^0.10.0
+  stac:
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   flutter_bloc: ^9.1.0

--- a/examples/movie_app/pubspec.yaml
+++ b/examples/movie_app/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  stac: ^1.0.1
-  stac_core: ^1.0.0
+  stac: 
+  stac_core: 
   dio: ^5.8.0+1
   smooth_page_indicator: ^1.2.1
   json_annotation: ^4.9.0

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -823,6 +823,28 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "icon": "text_fields"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Selectable Text"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A run of text with a single style that can be selected"
+    },
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/selectable_text_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "iconType": "cupertino",
       "icon": "textbox"
     },

--- a/examples/stac_gallery/assets/json/selectable_text_example.json
+++ b/examples/stac_gallery/assets/json/selectable_text_example.json
@@ -1,0 +1,117 @@
+{
+  "type": "scaffold",
+  "appBar": {
+    "type": "appBar",
+    "title": {
+      "type": "text",
+      "data": "Selectable Text"
+    }
+  },
+  "body": {
+    "type": "singleChildScrollView",
+    "child": {
+      "type": "padding",
+      "padding": {
+        "top": 12,
+        "left": 12,
+        "right": 12,
+        "bottom": 12
+      },
+      "child": {
+        "type": "column",
+        "crossAxisAlignment": "start",
+        "children": [
+          {
+            "type": "text",
+            "data": "Standard Selectable Text",
+            "style": {
+              "fontSize": 18,
+              "fontWeight": "w600"
+            }
+          },
+          {
+            "type": "sizedBox",
+            "height": 10
+          },
+          {
+            "type": "selectableText",
+            "data": "You can select this text. Long press or double tap to select."
+          },
+          {
+            "type": "sizedBox",
+            "height": 32
+          },
+          {
+            "type": "text",
+            "data": "Rich Selectable Text",
+            "style": {
+              "fontSize": 18,
+              "fontWeight": "w600"
+            }
+          },
+          {
+            "type": "sizedBox",
+            "height": 10
+          },
+          {
+            "type": "selectableText",
+            "data": "This is a ",
+            "children": [
+              {
+                "text": "selectable rich text.",
+                "style": {
+                  "fontWeight": "w800",
+                  "color": "#6700A4"
+                }
+              }
+            ]
+          },
+          {
+            "type": "sizedBox",
+            "height": 32
+          },
+          {
+            "type": "text",
+            "data": "Custom Cursor Selectable Text",
+            "style": {
+              "fontSize": 18,
+              "fontWeight": "w600"
+            }
+          },
+          {
+            "type": "sizedBox",
+            "height": 10
+          },
+          {
+            "type": "selectableText",
+            "data": "This text has a red cursor.",
+            "showCursor": true,
+            "cursorColor": "#000000",
+            "cursorWidth": 5.0
+          },
+          {
+            "type": "sizedBox",
+            "height": 32
+          },
+           {
+            "type": "text",
+            "data": "Interactive Selection Disabled",
+            "style": {
+              "fontSize": 18,
+              "fontWeight": "w600"
+            }
+          },
+          {
+            "type": "sizedBox",
+            "height": 10
+          },
+          {
+            "type": "selectableText",
+            "data": "You cannot select this text (interactive selection disabled).",
+            "enableInteractiveSelection": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/examples/stac_gallery/assets/json/selectable_text_example.json
+++ b/examples/stac_gallery/assets/json/selectable_text_example.json
@@ -86,14 +86,14 @@
             "type": "selectableText",
             "data": "This text has a red cursor.",
             "showCursor": true,
-            "cursorColor": "#000000",
+            "cursorColor": "#FF0000",
             "cursorWidth": 5.0
           },
           {
             "type": "sizedBox",
             "height": 32
           },
-           {
+          {
             "type": "text",
             "data": "Interactive Selection Disabled",
             "style": {

--- a/examples/stac_gallery/pubspec.yaml
+++ b/examples/stac_gallery/pubspec.yaml
@@ -37,8 +37,8 @@ dependencies:
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   flutter_bloc: ^9.1.0
-  stac: ^0.10.0
-  stac_webview: ^0.1.2
+  stac:
+  stac_webview:
   stac_core:
 
 dev_dependencies:

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -128,6 +128,7 @@ class StacService {
     const StacVisibilityParser(),
     const StacBackdropFilterParser(),
     const StacVerticalDividerParser(),
+    const StacSelectableTextParser(),
   ];
 
   static final _actionParsers = <StacActionParser>[

--- a/packages/stac/lib/src/parsers/actions/stac_set_value/stac_set_value_action_parser.dart
+++ b/packages/stac/lib/src/parsers/actions/stac_set_value/stac_set_value_action_parser.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:stac/src/parsers/core/stac_action_parser.dart';
 import 'package:stac/stac.dart';
 import 'package:stac_core/stac_core.dart';
 

--- a/packages/stac/lib/src/parsers/widgets/stac_app_bar/stac_app_bar_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_app_bar/stac_app_bar_parser.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/geometry/stac_edge_insets_parser.dart';
 import 'package:stac/src/parsers/foundation/layout/stac_clip_parser.dart';
 import 'package:stac/src/parsers/foundation/text/stac_text_style_parser.dart';

--- a/packages/stac/lib/src/parsers/widgets/stac_container/stac_container_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_container/stac_container_parser.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/alignment/stac_alignment_parser.dart';
 import 'package:stac/src/parsers/foundation/decoration/stac_box_decoration_parser.dart';
 import 'package:stac/src/parsers/foundation/geometry/stac_box_constraints_parser.dart';

--- a/packages/stac/lib/src/parsers/widgets/stac_inkwell/stac_inkwell_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_inkwell/stac_inkwell_parser.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:stac/src/parsers/core/stac_action_parser.dart';
-import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/animation/stac_duration_parsers.dart';
 import 'package:stac/src/parsers/foundation/borders/stac_border_radius_parser.dart';
 import 'package:stac/src/parsers/foundation/borders/stac_shape_border_parser.dart';

--- a/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
@@ -31,9 +31,11 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
       style: _resolveStyle(context, model.style, model.copyWithStyle),
       textAlign: model.textAlign?.parse,
       textDirection: model.textDirection?.parse,
-      textScaler: model.textScaleFactor != null
-          ? TextScaler.linear(model.textScaleFactor!)
-          : TextScaler.noScaling,
+      textScaler: model.textScaler != null
+          ? TextScaler.linear(model.textScaler!)
+          : model.textScaleFactor != null
+              ? TextScaler.linear(model.textScaleFactor!)
+              : null,
       showCursor: model.showCursor ?? false,
       autofocus: model.autofocus ?? false,
       minLines: model.minLines,
@@ -44,6 +46,7 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
           ? Radius.circular(model.cursorRadius!)
           : null,
       cursorColor: model.cursorColor?.toColor(context),
+      selectionColor: model.selectionColor?.toColor(context),
       enableInteractiveSelection: model.enableInteractiveSelection ?? true,
       semanticsLabel: model.semanticsLabel,
       textWidthBasis: model.textWidthBasis?.parse,
@@ -77,7 +80,7 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
 
     final overrideParsed = override.parse(context);
     if (overrideParsed == null) return baseStyle;
-    if (baseStyle == null) return null;
+    if (baseStyle == null) return overrideParsed;
 
     return baseStyle.copyWith(
       inherit: override.inherit,

--- a/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
@@ -33,8 +33,6 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
       textDirection: model.textDirection?.parse,
       textScaler: model.textScaler != null
           ? TextScaler.linear(model.textScaler!)
-          : model.textScaleFactor != null
-          ? TextScaler.linear(model.textScaleFactor!)
           : null,
       showCursor: model.showCursor ?? false,
       autofocus: model.autofocus ?? false,

--- a/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
@@ -100,6 +100,7 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
       debugLabel: overrideParsed.debugLabel,
       fontFamily: overrideParsed.fontFamily,
       fontFamilyFallback: overrideParsed.fontFamilyFallback,
+      package: overrideParsed.package,
       overflow: overrideParsed.overflow,
     );
   }

--- a/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:stac/src/framework/framework.dart';
+import 'package:stac/src/parsers/foundation/text/stac_text_align_parser.dart';
+import 'package:stac/src/parsers/foundation/text/stac_text_direction_parser.dart';
+import 'package:stac/src/parsers/foundation/text/stac_text_style_parser.dart';
+import 'package:stac/src/parsers/foundation/text/stac_text_width_basis_parser.dart';
+import 'package:stac/src/utils/color_utils.dart';
+import 'package:stac_core/foundation/specifications/widget_type.dart';
+import 'package:stac_core/foundation/text/stac_text_style/stac_text_style.dart';
+import 'package:stac_core/widgets/selectable_text/stac_selectable_text.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+class StacSelectableTextParser extends StacParser<StacSelectableText> {
+  const StacSelectableTextParser();
+
+  @override
+  String get type => WidgetType.selectableText.name;
+
+  @override
+  StacSelectableText getModel(Map<String, dynamic> json) =>
+      StacSelectableText.fromJson(json);
+
+  @override
+  Widget parse(BuildContext context, StacSelectableText model) {
+    return SelectableText.rich(
+      _buildTextSpan(context, model),
+      onTap: model.onTap != null
+          ? () => Stac.onCallFromJson(model.onTap?.toJson(), context)
+          : null,
+      style: _resolveStyle(context, model.style, model.copyWithStyle),
+      textAlign: model.textAlign?.parse,
+      textDirection: model.textDirection?.parse,
+      textScaler: model.textScaleFactor != null
+          ? TextScaler.linear(model.textScaleFactor!)
+          : TextScaler.noScaling,
+      showCursor: model.showCursor ?? false,
+      autofocus: model.autofocus ?? false,
+      minLines: model.minLines,
+      maxLines: model.maxLines,
+      cursorWidth: model.cursorWidth ?? 2.0,
+      cursorHeight: model.cursorHeight,
+      cursorRadius: model.cursorRadius != null
+          ? Radius.circular(model.cursorRadius!)
+          : null,
+      cursorColor: model.cursorColor?.toColor(context),
+      enableInteractiveSelection: model.enableInteractiveSelection ?? true,
+      semanticsLabel: model.semanticsLabel,
+      textWidthBasis: model.textWidthBasis?.parse,
+    );
+  }
+
+  TextSpan _buildTextSpan(BuildContext context, StacSelectableText model) {
+    var children = model.children ?? [];
+    return TextSpan(
+      text: model.data,
+      children: children.map((child) {
+        return TextSpan(
+          text: child.text,
+          style: child.style?.parse(context),
+          recognizer: child.onTap != null
+              ? (TapGestureRecognizer()
+                ..onTap = () => Stac.onCallFromJson(child.onTap, context))
+              : null,
+        );
+      }).toList(),
+    );
+  }
+
+  TextStyle? _resolveStyle(
+    BuildContext context,
+    StacTextStyle? base,
+    StacCustomTextStyle? override,
+  ) {
+    final baseStyle = base?.parse(context);
+    if (override == null) return baseStyle;
+
+    final overrideParsed = override.parse(context);
+    if (overrideParsed == null) return baseStyle;
+    if (baseStyle == null) return null;
+
+    return baseStyle.copyWith(
+      inherit: override.inherit,
+      color: overrideParsed.color,
+      backgroundColor: overrideParsed.backgroundColor,
+      fontSize: overrideParsed.fontSize,
+      fontWeight: overrideParsed.fontWeight,
+      fontStyle: overrideParsed.fontStyle,
+      letterSpacing: overrideParsed.letterSpacing,
+      wordSpacing: overrideParsed.wordSpacing,
+      textBaseline: overrideParsed.textBaseline,
+      height: overrideParsed.height,
+      leadingDistribution: overrideParsed.leadingDistribution,
+      decorationColor: overrideParsed.decorationColor,
+      decorationStyle: overrideParsed.decorationStyle,
+      decorationThickness: overrideParsed.decorationThickness,
+      debugLabel: overrideParsed.debugLabel,
+      fontFamily: overrideParsed.fontFamily,
+      fontFamilyFallback: overrideParsed.fontFamilyFallback,
+      overflow: overrideParsed.overflow,
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart
@@ -34,8 +34,8 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
       textScaler: model.textScaler != null
           ? TextScaler.linear(model.textScaler!)
           : model.textScaleFactor != null
-              ? TextScaler.linear(model.textScaleFactor!)
-              : null,
+          ? TextScaler.linear(model.textScaleFactor!)
+          : null,
       showCursor: model.showCursor ?? false,
       autofocus: model.autofocus ?? false,
       minLines: model.minLines,
@@ -63,7 +63,7 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
           style: child.style?.parse(context),
           recognizer: child.onTap != null
               ? (TapGestureRecognizer()
-                ..onTap = () => Stac.onCallFromJson(child.onTap, context))
+                  ..onTap = () => Stac.onCallFromJson(child.onTap, context))
               : null,
         );
       }).toList(),
@@ -100,7 +100,6 @@ class StacSelectableTextParser extends StacParser<StacSelectableText> {
       debugLabel: overrideParsed.debugLabel,
       fontFamily: overrideParsed.fontFamily,
       fontFamilyFallback: overrideParsed.fontFamilyFallback,
-      package: overrideParsed.package,
       overflow: overrideParsed.overflow,
     );
   }

--- a/packages/stac/lib/src/parsers/widgets/stac_switch/stac_switch_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_switch/stac_switch_parser.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:stac/src/parsers/core/stac_action_parser.dart';
-import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/interaction/stac_drag_start_behavior_parser.dart';
 import 'package:stac/src/parsers/foundation/layout/stac_material_tap_target_size_parser.dart';
 import 'package:stac/stac.dart';

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -57,6 +57,7 @@ export 'package:stac/src/parsers/widgets/stac_radio_group/stac_radio_group_parse
 export 'package:stac/src/parsers/widgets/stac_refresh_indicator/stac_refresh_indicator_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_safe_area/stac_safe_area_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_scaffold/stac_scaffold_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_selectable_text/stac_selectable_text_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_set_value/stac_set_value_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_single_child_scroll_view_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -189,6 +189,9 @@ enum WidgetType {
   /// Scaffold widget
   scaffold,
 
+  /// Selectable text widget
+  selectableText,
+
   /// Set value action/widget
   setValue,
 

--- a/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
+++ b/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
@@ -50,7 +50,6 @@ class StacSelectableText extends StacWidget {
     this.copyWithStyle,
     this.textAlign,
     this.textDirection,
-    @Deprecated('Use textScaler instead') this.textScaleFactor,
     this.textScaler,
     this.showCursor,
     this.autofocus,
@@ -84,10 +83,6 @@ class StacSelectableText extends StacWidget {
 
   /// The directionality of the text.
   final StacTextDirection? textDirection;
-
-  /// The number of font pixels for each logical pixel.
-  @Deprecated('Use textScaler instead')
-  final double? textScaleFactor;
 
   /// The font scaling strategy to use.
   final double? textScaler;

--- a/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
+++ b/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
@@ -1,0 +1,139 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_action.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/colors/stac_color/stac_colors.dart';
+import 'package:stac_core/foundation/specifications/widget_type.dart';
+import 'package:stac_core/foundation/text/stac_text_span/stac_text_span.dart';
+import 'package:stac_core/foundation/text/stac_text_style/stac_text_style.dart';
+import 'package:stac_core/foundation/text/stac_text_types.dart';
+
+part 'stac_selectable_text.g.dart';
+
+/// A widget that displays a string of text with a single style.
+///
+/// The string might break across multiple lines or might all be displayed on the same line depending on the layout constraints.
+///
+/// This widget corresponds to Flutter's [SelectableText] widget.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// StacSelectableText(
+///  data: 'Hello World',
+///  style: StacTextStyle(fontSize: 20, color: '#FF0000'),
+///  showCursor: true,
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "selectableText",
+///   "data": "Hello World",
+///   "style": {
+///     "fontSize": 20,
+///     "color": "#FF0000"
+///   },
+///   "showCursor": true
+/// }
+/// ```
+/// {@end-tool}
+@JsonSerializable()
+class StacSelectableText extends StacWidget {
+  /// Creates a [StacSelectableText].
+  const StacSelectableText({
+    required this.data,
+    this.children,
+    this.style,
+    this.copyWithStyle,
+    this.textAlign,
+    this.textDirection,
+    this.textScaleFactor,
+    this.showCursor,
+    this.autofocus,
+    this.minLines,
+    this.maxLines,
+    this.cursorWidth,
+    this.cursorHeight,
+    this.cursorRadius,
+    this.cursorColor,
+    this.enableInteractiveSelection,
+    this.onTap,
+    this.semanticsLabel,
+    this.textWidthBasis,
+    this.selectionColor,
+  });
+
+  /// The text to display.
+  final String data;
+
+  /// The list of text spans to display.
+  final List<StacTextSpan>? children;
+
+  /// The style to apply to the text.
+  final StacTextStyle? style;
+
+  /// The style to merge with the existing style.
+  final StacCustomTextStyle? copyWithStyle;
+
+  /// How the text should be aligned horizontally.
+  final StacTextAlign? textAlign;
+
+  /// The directionality of the text.
+  final StacTextDirection? textDirection;
+
+  /// The number of font pixels for each logical pixel.
+  final double? textScaleFactor;
+
+  /// Whether to show the cursor.
+  final bool? showCursor;
+
+  /// Whether this widget should focus itself if nothing else is already focused.
+  final bool? autofocus;
+
+  /// The minimum number of lines to occupy when the content spans fewer lines.
+  final int? minLines;
+
+  /// The maximum number of lines to display.
+  final int? maxLines;
+
+  /// The thickness of the cursor.
+  final double? cursorWidth;
+
+  /// The height of the cursor.
+  final double? cursorHeight;
+
+  /// The radius of the cursor.
+  final double? cursorRadius;
+
+  /// The color of the cursor.
+  final StacColor? cursorColor;
+
+  /// Whether to enable interactive selection.
+  final bool? enableInteractiveSelection;
+
+  /// Called when the user taps on the text.
+  final StacAction? onTap;
+
+  /// An alternative semantics label for the text.
+  final String? semanticsLabel;
+
+  /// Defines how the paragraph will measure the width of the text.
+  final StacTextWidthBasis? textWidthBasis;
+
+  /// The color to use when painting the selection.
+  final StacColor? selectionColor;
+
+  @override
+  String get type => WidgetType.selectableText.name;
+
+  /// Creates a [StacSelectableText] from a JSON map.
+  factory StacSelectableText.fromJson(Map<String, dynamic> json) =>
+      _$StacSelectableTextFromJson(json);
+
+  /// Converts this [StacSelectableText] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacSelectableTextToJson(this);
+}

--- a/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
+++ b/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.dart
@@ -50,7 +50,8 @@ class StacSelectableText extends StacWidget {
     this.copyWithStyle,
     this.textAlign,
     this.textDirection,
-    this.textScaleFactor,
+    @Deprecated('Use textScaler instead') this.textScaleFactor,
+    this.textScaler,
     this.showCursor,
     this.autofocus,
     this.minLines,
@@ -85,7 +86,11 @@ class StacSelectableText extends StacWidget {
   final StacTextDirection? textDirection;
 
   /// The number of font pixels for each logical pixel.
+  @Deprecated('Use textScaler instead')
   final double? textScaleFactor;
+
+  /// The font scaling strategy to use.
+  final double? textScaler;
 
   /// Whether to show the cursor.
   final bool? showCursor;

--- a/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.g.dart
+++ b/packages/stac_core/lib/widgets/selectable_text/stac_selectable_text.g.dart
@@ -1,0 +1,91 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_selectable_text.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSelectableText _$StacSelectableTextFromJson(Map<String, dynamic> json) =>
+    StacSelectableText(
+      data: json['data'] as String,
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => StacTextSpan.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      style: json['style'] == null
+          ? null
+          : StacTextStyle.fromJson(json['style']),
+      copyWithStyle: json['copyWithStyle'] == null
+          ? null
+          : StacCustomTextStyle.fromJson(
+              json['copyWithStyle'] as Map<String, dynamic>,
+            ),
+      textAlign: $enumDecodeNullable(_$StacTextAlignEnumMap, json['textAlign']),
+      textDirection: $enumDecodeNullable(
+        _$StacTextDirectionEnumMap,
+        json['textDirection'],
+      ),
+      textScaler: (json['textScaler'] as num?)?.toDouble(),
+      showCursor: json['showCursor'] as bool?,
+      autofocus: json['autofocus'] as bool?,
+      minLines: (json['minLines'] as num?)?.toInt(),
+      maxLines: (json['maxLines'] as num?)?.toInt(),
+      cursorWidth: (json['cursorWidth'] as num?)?.toDouble(),
+      cursorHeight: (json['cursorHeight'] as num?)?.toDouble(),
+      cursorRadius: (json['cursorRadius'] as num?)?.toDouble(),
+      cursorColor: json['cursorColor'] as String?,
+      enableInteractiveSelection: json['enableInteractiveSelection'] as bool?,
+      onTap: json['onTap'] == null
+          ? null
+          : StacAction.fromJson(json['onTap'] as Map<String, dynamic>),
+      semanticsLabel: json['semanticsLabel'] as String?,
+      textWidthBasis: $enumDecodeNullable(
+        _$StacTextWidthBasisEnumMap,
+        json['textWidthBasis'],
+      ),
+      selectionColor: json['selectionColor'] as String?,
+    );
+
+Map<String, dynamic> _$StacSelectableTextToJson(StacSelectableText instance) =>
+    <String, dynamic>{
+      'data': instance.data,
+      'children': instance.children?.map((e) => e.toJson()).toList(),
+      'style': instance.style?.toJson(),
+      'copyWithStyle': instance.copyWithStyle?.toJson(),
+      'textAlign': _$StacTextAlignEnumMap[instance.textAlign],
+      'textDirection': _$StacTextDirectionEnumMap[instance.textDirection],
+      'textScaler': instance.textScaler,
+      'showCursor': instance.showCursor,
+      'autofocus': instance.autofocus,
+      'minLines': instance.minLines,
+      'maxLines': instance.maxLines,
+      'cursorWidth': instance.cursorWidth,
+      'cursorHeight': instance.cursorHeight,
+      'cursorRadius': instance.cursorRadius,
+      'cursorColor': instance.cursorColor,
+      'enableInteractiveSelection': instance.enableInteractiveSelection,
+      'onTap': instance.onTap?.toJson(),
+      'semanticsLabel': instance.semanticsLabel,
+      'textWidthBasis': _$StacTextWidthBasisEnumMap[instance.textWidthBasis],
+      'selectionColor': instance.selectionColor,
+      'type': instance.type,
+    };
+
+const _$StacTextAlignEnumMap = {
+  StacTextAlign.left: 'left',
+  StacTextAlign.right: 'right',
+  StacTextAlign.center: 'center',
+  StacTextAlign.justify: 'justify',
+  StacTextAlign.start: 'start',
+  StacTextAlign.end: 'end',
+};
+
+const _$StacTextDirectionEnumMap = {
+  StacTextDirection.rtl: 'rtl',
+  StacTextDirection.ltr: 'ltr',
+};
+
+const _$StacTextWidthBasisEnumMap = {
+  StacTextWidthBasis.parent: 'parent',
+  StacTextWidthBasis.longestLine: 'longestLine',
+};

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -61,6 +61,7 @@ export 'refresh_indicator/stac_refresh_indicator.dart';
 export 'row/stac_row.dart';
 export 'safe_area/stac_safe_area.dart';
 export 'scaffold/stac_scaffold.dart';
+export 'selectable_text/stac_selectable_text.dart';
 export 'set_value/stac_set_value.dart';
 export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Adds `SelectableText` widget support end-to-end (core widget + framework parser).
- Registers the new widget type and exports it through existing widget registries.
- Adds docs page for `SelectableText` and includes it in the docs index.
- Updates `stac_gallery` JSON to include a `SelectableText` example and wires it into the gallery home screen.

<!--- List the related issues to this PR -->
Closes #385 

## Preview

https://github.com/user-attachments/assets/0e3b9519-ca4d-454c-93cd-27781a9ba77a


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SelectableText widget with rich selectable spans, cursor customization, interactive-selection control, tap callbacks, and text scaling.

* **Documentation**
  * Added detailed docs with properties, migration note, and JSON usage examples; updated docs navigation.

* **Examples**
  * Added gallery entry and example screen demonstrating standard, rich, custom-cursor, and non-interactive selectable text.

* **Chores**
  * Added JSON (de)serialization support and unpinned example dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->