### PR TITLE
feat: Introduce StacTooltipThemeData and parser

### DIFF
--- a/packages/stac/lib/src/parsers/theme/stac_theme_parser.dart
+++ b/packages/stac/lib/src/parsers/theme/stac_theme_parser.dart
@@ -27,6 +27,7 @@ import 'package:stac/src/parsers/theme/stac_scrollbar_theme_data_parser.dart';
 import 'package:stac/src/parsers/theme/stac_snack_bar_theme_data_parser.dart';
 import 'package:stac/src/parsers/theme/stac_tab_bar_theme_data_parser.dart';
 import 'package:stac/src/parsers/theme/stac_text_theme_parser.dart';
+import 'package:stac/src/parsers/theme/stac_tool_tip_theme_data_parser.dart';
 import 'package:stac/src/utils/color_utils.dart';
 import 'package:stac_core/stac_core.dart';
 
@@ -125,7 +126,7 @@ extension StacThemeParser on StacTheme {
       // TextSelectionThemeData? textSelectionTheme,
       // TimePickerThemeData? timePickerTheme,
       // ToggleButtonsThemeData? toggleButtonsTheme,
-      // TooltipThemeData? tooltipTheme,
+      tooltipTheme: tooltipTheme?.parse(context),
     );
   }
 }

--- a/packages/stac/lib/src/parsers/theme/stac_tool_tip_theme_data_parser.dart
+++ b/packages/stac/lib/src/parsers/theme/stac_tool_tip_theme_data_parser.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:stac/src/parsers/foundation/foundation.dart';
+import 'package:stac_core/stac_core.dart';
+
+/// Parser extension for [StacTooltipThemeData].
+///
+/// Converts [StacTooltipThemeData] to Flutter's [TooltipThemeData].
+extension StacTooltipThemeDataParser on StacTooltipThemeData {
+  TooltipThemeData parse(BuildContext context) {
+    return TooltipThemeData(
+      constraints: constraints?.parse,
+      padding: padding?.parse,
+      margin: margin?.parse,
+      verticalOffset: verticalOffset,
+      preferBelow: preferBelow,
+      excludeFromSemantics: excludeFromSemantics,
+      decoration: decoration?.parse(context),
+      textStyle: textStyle?.parse(context),
+      textAlign: textAlign?.parse,
+      waitDuration: waitDuration?.parse,
+      showDuration: showDuration?.parse,
+      exitDuration: exitDuration?.parse,
+      triggerMode: triggerMode?.parse,
+      enableFeedback: enableFeedback,
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/theme/themes.dart
+++ b/packages/stac/lib/src/parsers/theme/themes.dart
@@ -26,7 +26,8 @@ export 'package:stac_core/stac_core.dart'
         StacSnackBarThemeData,
         StacTabBarThemeData,
         StacTextTheme,
-        StacTheme;
+        StacTheme,
+        StacTooltipThemeData;
 
 // Export parsers
 export 'stac_app_bar_theme_parser.dart';
@@ -55,3 +56,4 @@ export 'stac_snack_bar_theme_data_parser.dart';
 export 'stac_tab_bar_theme_data_parser.dart';
 export 'stac_text_theme_parser.dart';
 export 'stac_theme_parser.dart';
+export 'stac_tool_tip_theme_data_parser.dart';

--- a/packages/stac_core/lib/foundation/theme/stac_theme/stac_theme.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_theme/stac_theme.dart
@@ -28,6 +28,7 @@ import 'package:stac_core/foundation/theme/stac_scrollbar_theme_data/stac_scroll
 import 'package:stac_core/foundation/theme/stac_snack_bar_theme_data/stac_snack_bar_theme_data.dart';
 import 'package:stac_core/foundation/theme/stac_tab_bar_theme_data/stac_tab_bar_theme_data.dart';
 import 'package:stac_core/foundation/theme/stac_text_theme/stac_text_theme.dart';
+import 'package:stac_core/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart';
 
 part 'stac_theme.g.dart';
 
@@ -155,7 +156,7 @@ class StacTheme implements StacElement {
     // TextSelectionThemeData? textSelectionTheme,
     // TimePickerThemeData? timePickerTheme,
     // ToggleButtonsThemeData? toggleButtonsTheme,
-    // TooltipThemeData? tooltipTheme,
+    this.tooltipTheme,
   });
 
   // GENERAL CONFIGURATION
@@ -371,7 +372,9 @@ class StacTheme implements StacElement {
   // TextSelectionThemeData? textSelectionTheme,
   // TimePickerThemeData? timePickerTheme,
   // ToggleButtonsThemeData? toggleButtonsTheme,
-  // TooltipThemeData? tooltipTheme,
+
+  /// The theme for [Tooltip] widgets.
+  final StacTooltipThemeData? tooltipTheme;
 
   /// Creates a [StacTheme] from JSON.
   factory StacTheme.fromJson(Map<String, dynamic> json) =>

--- a/packages/stac_core/lib/foundation/theme/stac_theme/stac_theme.g.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_theme/stac_theme.g.dart
@@ -194,6 +194,11 @@ StacTheme _$StacThemeFromJson(Map<String, dynamic> json) => StacTheme(
       : StacButtonStyle.fromJson(
           json['textButtonTheme'] as Map<String, dynamic>,
         ),
+  tooltipTheme: json['tooltipTheme'] == null
+      ? null
+      : StacTooltipThemeData.fromJson(
+          json['tooltipTheme'] as Map<String, dynamic>,
+        ),
 );
 
 Map<String, dynamic> _$StacThemeToJson(StacTheme instance) => <String, dynamic>{
@@ -256,6 +261,7 @@ Map<String, dynamic> _$StacThemeToJson(StacTheme instance) => <String, dynamic>{
   'snackBarTheme': instance.snackBarTheme?.toJson(),
   'tabBarTheme': instance.tabBarTheme?.toJson(),
   'textButtonTheme': instance.textButtonTheme?.toJson(),
+  'tooltipTheme': instance.tooltipTheme?.toJson(),
 };
 
 const _$StacMaterialTapTargetSizeEnumMap = {

--- a/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart
@@ -35,7 +35,6 @@ part 'stac_tool_tip_theme_data.g.dart';
 class StacTooltipThemeData implements StacElement {
   /// Creates a [StacTooltipThemeData] with the given properties.
   const StacTooltipThemeData({
-    this.height,
     this.constraints,
     this.padding,
     this.margin,
@@ -51,9 +50,6 @@ class StacTooltipThemeData implements StacElement {
     this.triggerMode,
     this.enableFeedback,
   });
-
-  /// Minimum height of the tooltip.
-  final double? height;
 
   /// Size constraints for the tooltip.
   final StacBoxConstraints? constraints;

--- a/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart
@@ -1,0 +1,106 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/stac_core.dart';
+
+part 'stac_tool_tip_theme_data.g.dart';
+
+/// A Stac model representing Flutter's [TooltipThemeData].
+///
+/// Defines default visual and behavioral properties for [Tooltip] widgets.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// StacTooltipThemeData(
+///   padding: StacEdgeInsets.all(8),
+///   textStyle: StacTextStyle(color: '#FFFFFF'),
+///   preferBelow: true,
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "padding": { "all": 8 },
+///   "margin": { "horizontal": 12 },
+///   "verticalOffset": 24,
+///   "preferBelow": true,
+///   "textStyle": { "color": "#FFFFFF", "fontSize": 12 },
+///   "triggerMode": "longPress"
+/// }
+/// ```
+/// {@end-tool}
+@JsonSerializable()
+class StacTooltipThemeData implements StacElement {
+  /// Creates a [StacTooltipThemeData] with the given properties.
+  const StacTooltipThemeData({
+    this.height,
+    this.constraints,
+    this.padding,
+    this.margin,
+    this.verticalOffset,
+    this.preferBelow,
+    this.excludeFromSemantics,
+    this.decoration,
+    this.textStyle,
+    this.textAlign,
+    this.waitDuration,
+    this.showDuration,
+    this.exitDuration,
+    this.triggerMode,
+    this.enableFeedback,
+  });
+
+  /// Minimum height of the tooltip.
+  final double? height;
+
+  /// Size constraints for the tooltip.
+  final StacBoxConstraints? constraints;
+
+  /// Padding inside the tooltip.
+  final StacEdgeInsets? padding;
+
+  /// Margin around the tooltip.
+  final StacEdgeInsets? margin;
+
+  /// Vertical gap between widget and tooltip.
+  final double? verticalOffset;
+
+  /// Whether tooltip prefers to appear below the widget.
+  final bool? preferBelow;
+
+  /// Whether tooltip text is excluded from semantics.
+  final bool? excludeFromSemantics;
+
+  /// Tooltip decoration.
+  final StacBoxDecoration? decoration;
+
+  /// Tooltip text style.
+  final StacTextStyle? textStyle;
+
+  /// Tooltip text alignment.
+  final StacTextAlign? textAlign;
+
+  /// Delay before showing tooltip.
+  final StacDuration? waitDuration;
+
+  /// Duration tooltip remains visible.
+  final StacDuration? showDuration;
+
+  /// Delay before tooltip disappears.
+  final StacDuration? exitDuration;
+
+  /// Trigger mode for tooltip.
+  final StacTooltipTriggerMode? triggerMode;
+
+  /// Whether to provide acoustic/haptic feedback.
+  final bool? enableFeedback;
+
+  /// Creates a [StacTooltipThemeData] from JSON.
+  factory StacTooltipThemeData.fromJson(Map<String, dynamic> json) =>
+      _$StacTooltipThemeDataFromJson(json);
+
+  @override
+  Map<String, dynamic> toJson() => _$StacTooltipThemeDataToJson(this);
+}

--- a/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.g.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.g.dart
@@ -1,0 +1,83 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_tool_tip_theme_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacTooltipThemeData _$StacTooltipThemeDataFromJson(
+  Map<String, dynamic> json,
+) => StacTooltipThemeData(
+  height: (json['height'] as num?)?.toDouble(),
+  constraints: json['constraints'] == null
+      ? null
+      : StacBoxConstraints.fromJson(
+          json['constraints'] as Map<String, dynamic>,
+        ),
+  padding: json['padding'] == null
+      ? null
+      : StacEdgeInsets.fromJson(json['padding']),
+  margin: json['margin'] == null
+      ? null
+      : StacEdgeInsets.fromJson(json['margin']),
+  verticalOffset: (json['verticalOffset'] as num?)?.toDouble(),
+  preferBelow: json['preferBelow'] as bool?,
+  excludeFromSemantics: json['excludeFromSemantics'] as bool?,
+  decoration: json['decoration'] == null
+      ? null
+      : StacBoxDecoration.fromJson(json['decoration'] as Map<String, dynamic>),
+  textStyle: json['textStyle'] == null
+      ? null
+      : StacTextStyle.fromJson(json['textStyle']),
+  textAlign: $enumDecodeNullable(_$StacTextAlignEnumMap, json['textAlign']),
+  waitDuration: json['waitDuration'] == null
+      ? null
+      : StacDuration.fromJson(json['waitDuration'] as Map<String, dynamic>),
+  showDuration: json['showDuration'] == null
+      ? null
+      : StacDuration.fromJson(json['showDuration'] as Map<String, dynamic>),
+  exitDuration: json['exitDuration'] == null
+      ? null
+      : StacDuration.fromJson(json['exitDuration'] as Map<String, dynamic>),
+  triggerMode: $enumDecodeNullable(
+    _$StacTooltipTriggerModeEnumMap,
+    json['triggerMode'],
+  ),
+  enableFeedback: json['enableFeedback'] as bool?,
+);
+
+Map<String, dynamic> _$StacTooltipThemeDataToJson(
+  StacTooltipThemeData instance,
+) => <String, dynamic>{
+  'height': instance.height,
+  'constraints': instance.constraints?.toJson(),
+  'padding': instance.padding?.toJson(),
+  'margin': instance.margin?.toJson(),
+  'verticalOffset': instance.verticalOffset,
+  'preferBelow': instance.preferBelow,
+  'excludeFromSemantics': instance.excludeFromSemantics,
+  'decoration': instance.decoration?.toJson(),
+  'textStyle': instance.textStyle?.toJson(),
+  'textAlign': _$StacTextAlignEnumMap[instance.textAlign],
+  'waitDuration': instance.waitDuration?.toJson(),
+  'showDuration': instance.showDuration?.toJson(),
+  'exitDuration': instance.exitDuration?.toJson(),
+  'triggerMode': _$StacTooltipTriggerModeEnumMap[instance.triggerMode],
+  'enableFeedback': instance.enableFeedback,
+};
+
+const _$StacTextAlignEnumMap = {
+  StacTextAlign.left: 'left',
+  StacTextAlign.right: 'right',
+  StacTextAlign.center: 'center',
+  StacTextAlign.justify: 'justify',
+  StacTextAlign.start: 'start',
+  StacTextAlign.end: 'end',
+};
+
+const _$StacTooltipTriggerModeEnumMap = {
+  StacTooltipTriggerMode.manual: 'manual',
+  StacTooltipTriggerMode.longPress: 'longPress',
+  StacTooltipTriggerMode.tap: 'tap',
+};

--- a/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.g.dart
+++ b/packages/stac_core/lib/foundation/theme/stac_tool_tip_theme_data/stac_tool_tip_theme_data.g.dart
@@ -9,7 +9,6 @@ part of 'stac_tool_tip_theme_data.dart';
 StacTooltipThemeData _$StacTooltipThemeDataFromJson(
   Map<String, dynamic> json,
 ) => StacTooltipThemeData(
-  height: (json['height'] as num?)?.toDouble(),
   constraints: json['constraints'] == null
       ? null
       : StacBoxConstraints.fromJson(
@@ -50,7 +49,6 @@ StacTooltipThemeData _$StacTooltipThemeDataFromJson(
 Map<String, dynamic> _$StacTooltipThemeDataToJson(
   StacTooltipThemeData instance,
 ) => <String, dynamic>{
-  'height': instance.height,
   'constraints': instance.constraints?.toJson(),
   'padding': instance.padding?.toJson(),
   'margin': instance.margin?.toJson(),

--- a/packages/stac_core/lib/foundation/theme/theme.dart
+++ b/packages/stac_core/lib/foundation/theme/theme.dart
@@ -28,3 +28,4 @@ export 'stac_snack_bar_theme_data/stac_snack_bar_theme_data.dart';
 export 'stac_tab_bar_theme_data/stac_tab_bar_theme_data.dart';
 export 'stac_text_theme/stac_text_theme.dart';
 export 'stac_theme/stac_theme.dart';
+export 'stac_tool_tip_theme_data/stac_tool_tip_theme_data.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Add support for `StacTooltipThemeData` in Stac.

<!--- ## Related Issues -->

<!--- List the related issues to this PR -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltip theming is now supported, allowing customization of appearance, sizing, spacing, durations, alignment and trigger modes.
  * Theme-level tooltip settings are exposed and applied at runtime via the app theme.
  * Tooltip theme objects are serializable to/from JSON, enabling persistence and configuration sharing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->