### PR TITLE
feat: add stacSliverPadding widget, parser,example and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,6 +68,7 @@
                             "widgets/row",
                             "widgets/safe_area",
                             "widgets/sized_box",
+                            "widgets/sliver_padding",
                             "widgets/spacer",
                             "widgets/stack",
                             "widgets/wrap",

--- a/docs/widgets/sliver_padding.mdx
+++ b/docs/widgets/sliver_padding.mdx
@@ -1,0 +1,40 @@
+---
+title: "SliverPadding"
+description: "Documentation for SliverPadding"
+---
+
+The Stac SliverPadding allows you to inset a sliver widget by a given padding using JSON. It is typically used inside a `CustomScrollView`.
+To know more about the sliver padding widget in Flutter, refer to
+the [official documentation](https://api.flutter.dev/flutter/widgets/SliverPadding-class.html).
+
+## Properties
+
+| Property | Type                    | Description                                       |
+|----------|-------------------------|---------------------------------------------------|
+| padding  | `Map<String, dynamic>`  | The amount of space by which to inset the child.  |
+| sliver   | `Map<String, dynamic>`  | The sliver widget inside the padding.             |
+
+## Example JSON
+
+```json
+{
+  "type": "sliverPadding",
+  "padding": {
+    "all": 16
+  },
+  "sliver": {
+    "type": "sliverList",
+    "delegate": {
+      "children": [
+        {
+          "type": "text",
+          "data": "Item 1"
+        },
+        {
+          "type": "text",
+          "data": "Item 2"
+        }
+      ]
+    }
+  }
+}

--- a/docs/widgets/sliver_padding.mdx
+++ b/docs/widgets/sliver_padding.mdx
@@ -9,10 +9,10 @@ the [official documentation](https://api.flutter.dev/flutter/widgets/SliverPaddi
 
 ## Properties
 
-| Property | Type                    | Description                                       |
-|----------|-------------------------|---------------------------------------------------|
-| padding  | `Map<String, dynamic>`  | The amount of space by which to inset the child.  |
-| sliver   | `Map<String, dynamic>`  | The sliver widget inside the padding.             |
+| Property | Type                   | Description                                      |
+|----------|------------------------|--------------------------------------------------|
+| padding  | `Map<String, dynamic>` | The amount of space by which to inset the child. |
+| sliver   | `Map<String, dynamic>` | The sliver widget inside the padding.            |
 
 ## Example JSON
 
@@ -20,21 +20,26 @@ the [official documentation](https://api.flutter.dev/flutter/widgets/SliverPaddi
 {
   "type": "sliverPadding",
   "padding": {
-    "all": 16
+    "all": 16.0
   },
   "sliver": {
-    "type": "sliverList",
-    "delegate": {
-      "children": [
-        {
+    "type": "sliverToBoxAdapter",
+    "child": {
+      "type": "container",
+      "height": 150,
+      "color": "#4CAF50",
+      "child": {
+        "type": "center",
+        "child": {
           "type": "text",
-          "data": "Item 1"
-        },
-        {
-          "type": "text",
-          "data": "Item 2"
+          "data": "I am a Box inside a SliverPadding!",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
         }
-      ]
+      }
     }
   }
 }
+```

--- a/docs/widgets/sliver_padding.mdx
+++ b/docs/widgets/sliver_padding.mdx
@@ -19,9 +19,7 @@ the [official documentation](https://api.flutter.dev/flutter/widgets/SliverPaddi
 ```json
 {
   "type": "sliverPadding",
-  "padding": {
-    "all": 16.0
-  },
+  "padding": 16.0,
   "sliver": {
     "type": "sliverToBoxAdapter",
     "child": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1249,7 +1249,7 @@
     },
     "subtitle": {
       "type": "text",
-      "data": "A Material Design Sliver Padding widget"
+      "data": "A Material Design SliverPadding widget"
     },
     "style": "list",
     "onTap": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1249,7 +1249,7 @@
     },
     "subtitle": {
       "type": "text",
-      "data": "A Material Design SliverPadding widget"
+      "data": "A SliverPadding widget"
     },
     "style": "list",
     "onTap": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1240,6 +1240,30 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "iconType": "cupertino",
+      "icon": "app_fill"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Sliver Padding"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Material Design Sliver Padding widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_padding_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "icon": "navigation"
     },
     "title": {

--- a/examples/stac_gallery/assets/json/sliver_padding_example.json
+++ b/examples/stac_gallery/assets/json/sliver_padding_example.json
@@ -5,9 +5,7 @@
         "slivers": [
             {
                 "type": "sliverPadding",
-                "padding": {
-                    "all": 16.0
-                },
+                "padding": 16.0,
                 "sliver": {
                     "type": "sliverToBoxAdapter",
                     "child": {

--- a/examples/stac_gallery/assets/json/sliver_padding_example.json
+++ b/examples/stac_gallery/assets/json/sliver_padding_example.json
@@ -1,0 +1,33 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverPadding",
+                "padding": {
+                    "all": 16.0
+                },
+                "sliver": {
+                    "type": "sliverToBoxAdapter",
+                    "child": {
+                        "type": "container",
+                        "height": 150,
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "I am a Box inside a SliverPadding!",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverPaddingParser(),
     const StacOpacityParser(),
     const StacPlaceholderParser(),
     const StacAspectRatioParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_padding/stac_sliver_padding_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_padding/stac_sliver_padding_parser.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+
+import 'package:stac/src/parsers/foundation/geometry/stac_edge_insets_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+class StacSliverPaddingParser extends StacParser<StacSliverPadding> {
+  const StacSliverPaddingParser();
+
+  @override
+  String get type => WidgetType.sliverPadding.name;
+
+  @override
+  StacSliverPadding getModel(Map<String, dynamic> json) =>
+      StacSliverPadding.fromJson(json);
+
+  @override
+  Widget parse(BuildContext context, StacSliverPadding model) {
+    return SliverPadding(
+      padding: model.padding.parse,
+      sliver: model.sliver.parse(context),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -63,6 +63,7 @@ export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_sing
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_padding/stac_sliver_padding_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_spacer/stac_spacer_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_stack/stac_stack_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_switch/stac_switch_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver padding widget
+  sliverPadding,
+
   /// Spacer widget
   spacer,
 

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -22,9 +22,7 @@ part 'stac_sliver_padding.g.dart';
 /// ```json
 /// {
 ///     "type": "sliverPadding",
-///     "padding": {
-///         "all": 16.0
-///     },
+///     "padding": 16.0,
 ///     "sliver": {
 ///         "type": "sliverToBoxAdapter",
 ///         "child": {

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -12,7 +12,7 @@ part 'stac_sliver_padding.g.dart';
 /// ```dart
 /// const StacSliverPadding(
 ///   padding: StacEdgeInsets.all(16),
-///   sliver: StacSliverList(...),
+///   sliver: StacSliverToBoxAdapter(...),
 /// )
 /// ```
 /// {@end-tool}
@@ -20,16 +20,31 @@ part 'stac_sliver_padding.g.dart';
 /// {@tool snippet}
 /// JSON Example:
 /// ```json
-/// {
-///   "type": "sliverPadding",
-///   "padding": { "all": 16 },
-///   "sliver": {
-///     "type": "sliverList",
-///     "children": [
-///       { "type": "text", "data": "Item 1" }
-///     ]
-///   }
-/// }
+// {
+//     "type": "sliverPadding",
+//     "padding": {
+//         "all": 16.0
+//     },
+//     "sliver": {
+//         "type": "sliverToBoxAdapter",
+//         "child": {
+//             "type": "container",
+//             "height": 150,
+//             "color": "#4CAF50",
+//             "child": {
+//                 "type": "center",
+//                 "child": {
+//                     "type": "text",
+//                     "data": "I am a Box inside a SliverPadding!",
+//                     "style": {
+//                         "color": "#FFFFFF",
+//                         "fontWeight": "bold"
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -48,7 +48,7 @@ part 'stac_sliver_padding.g.dart';
 ///
 /// See also:
 ///  * Flutter's [SliverPadding documentation](https://api.flutter.dev/flutter/widgets/SliverPadding-class.html)
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class StacSliverPadding extends StacWidget {
   /// Creates a [StacSliverPadding].
   const StacSliverPadding({required this.sliver, required this.padding});

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -1,0 +1,60 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+part 'stac_sliver_padding.g.dart';
+
+/// A Stac model representing Flutter's [SliverPadding] widget.
+///
+/// Insets its sliver child by the given padding.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverPadding(
+///   padding: StacEdgeInsets.all(16),
+///   sliver: StacSliverList(...),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "sliverPadding",
+///   "padding": { "all": 16 },
+///   "sliver": {
+///     "type": "sliverList",
+///     "children": [
+///       { "type": "text", "data": "Item 1" }
+///     ]
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverPadding documentation](https://api.flutter.dev/flutter/widgets/SliverPadding-class.html)
+@JsonSerializable()
+class StacSliverPadding extends StacWidget {
+  /// Creates a [StacSliverPadding].
+  const StacSliverPadding({required this.sliver, required this.padding});
+
+  /// The amount of space by which to inset the child sliver.
+  final StacEdgeInsets padding;
+
+  /// The sliver to apply padding to.
+  final StacWidget sliver;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.sliverPadding.name;
+
+  /// Creates a [StacSliverPadding] from a JSON map.
+  factory StacSliverPadding.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverPaddingFromJson(json);
+
+  /// Converts this [StacSliverPadding] instance to JSON.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverPaddingToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -48,7 +48,7 @@ part 'stac_sliver_padding.g.dart';
 ///
 /// See also:
 ///  * Flutter's [SliverPadding documentation](https://api.flutter.dev/flutter/widgets/SliverPadding-class.html)
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable()
 class StacSliverPadding extends StacWidget {
   /// Creates a [StacSliverPadding].
   const StacSliverPadding({required this.sliver, required this.padding});

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.dart
@@ -20,31 +20,31 @@ part 'stac_sliver_padding.g.dart';
 /// {@tool snippet}
 /// JSON Example:
 /// ```json
-// {
-//     "type": "sliverPadding",
-//     "padding": {
-//         "all": 16.0
-//     },
-//     "sliver": {
-//         "type": "sliverToBoxAdapter",
-//         "child": {
-//             "type": "container",
-//             "height": 150,
-//             "color": "#4CAF50",
-//             "child": {
-//                 "type": "center",
-//                 "child": {
-//                     "type": "text",
-//                     "data": "I am a Box inside a SliverPadding!",
-//                     "style": {
-//                         "color": "#FFFFFF",
-//                         "fontWeight": "bold"
-//                     }
-//                 }
-//             }
-//         }
-//     }
-// }
+/// {
+///     "type": "sliverPadding",
+///     "padding": {
+///         "all": 16.0
+///     },
+///     "sliver": {
+///         "type": "sliverToBoxAdapter",
+///         "child": {
+///             "type": "container",
+///             "height": 150,
+///             "color": "#4CAF50",
+///             "child": {
+///                 "type": "center",
+///                 "child": {
+///                     "type": "text",
+///                     "data": "I am a Box inside a SliverPadding!",
+///                     "style": {
+///                         "color": "#FFFFFF",
+///                         "fontWeight": "bold"
+///                     }
+///                 }
+///             }
+///         }
+///     }
+/// }
 /// ```
 /// {@end-tool}
 ///

--- a/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_padding/stac_sliver_padding.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_padding.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverPadding _$StacSliverPaddingFromJson(Map<String, dynamic> json) =>
+    StacSliverPadding(
+      sliver: StacWidget.fromJson(json['sliver'] as Map<String, dynamic>),
+      padding: StacEdgeInsets.fromJson(json['padding']),
+    );
+
+Map<String, dynamic> _$StacSliverPaddingToJson(StacSliverPadding instance) =>
+    <String, dynamic>{
+      'padding': instance.padding.toJson(),
+      'sliver': instance.sliver.toJson(),
+      'type': instance.type,
+    };

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -67,6 +67,7 @@ export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
+export 'sliver_padding/stac_sliver_padding.dart';
 export 'spacer/stac_spacer.dart';
 export 'stack/stac_stack.dart';
 export 'switch/stac_switch.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for stacSliverPadding by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #417

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SliverPadding support for padded slivers in scrollable layouts.

* **Documentation**
  * Added a docs page describing SliverPadding, its properties, and a usage example.

* **Examples**
  * Added a gallery entry and an interactive example demonstrating a padded sliver with a styled box.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->