### PR TITLE
feat: add stacSliverToBoxAdapter widget, parser,example and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -68,6 +68,7 @@
                             "widgets/row",
                             "widgets/safe_area",
                             "widgets/sized_box",
+                            "widgets/sliver_to_box_adapter",
                             "widgets/spacer",
                             "widgets/stack",
                             "widgets/wrap",

--- a/docs/widgets/sliver_to_box_adapter.mdx
+++ b/docs/widgets/sliver_to_box_adapter.mdx
@@ -3,8 +3,8 @@ title: "SliverToBoxAdapter"
 description: "Documentation for SliverToBoxAdapter"
 ---
 
-The Stac SliverToBoxAdapter allows you to build a Flutter sliver to box adapter widget using JSON. It creates a sliver that contains a single box widget.
-To know more about the sliver to box adapter widget in Flutter, refer to
+The Stac SliverToBoxAdapter allows you to build a Flutter sliver-to-box-adapter widget using JSON. It creates a sliver that contains a single box widget.
+To know more about the sliver-to-box-adapter widget in Flutter, refer to
 the [official documentation](https://api.flutter.dev/flutter/widgets/SliverToBoxAdapter-class.html).
 
 ## Properties

--- a/docs/widgets/sliver_to_box_adapter.mdx
+++ b/docs/widgets/sliver_to_box_adapter.mdx
@@ -1,0 +1,33 @@
+---
+title: "SliverToBoxAdapter"
+description: "Documentation for SliverToBoxAdapter"
+---
+
+The Stac SliverToBoxAdapter allows you to build a Flutter sliver to box adapter widget using JSON. It creates a sliver that contains a single box widget.
+To know more about the sliver to box adapter widget in Flutter, refer to
+the [official documentation](https://api.flutter.dev/flutter/widgets/SliverToBoxAdapter-class.html).
+
+## Properties
+
+| Property | Type                    | Description                          |
+|----------|-------------------------|--------------------------------------|
+| child    | `Map<String, dynamic>?` | The widget contained by this sliver. |
+
+## Example JSON
+
+```json
+{
+  "type": "sliverToBoxAdapter",
+  "child": {
+    "type": "container",
+    "height": 200,
+    "color": "#FF5733",
+    "child": {
+      "type": "center",
+      "child": {
+        "type": "text",
+        "data": "I am a Box inside a Sliver!"
+      }
+    }
+  }
+}

--- a/docs/widgets/sliver_to_box_adapter.mdx
+++ b/docs/widgets/sliver_to_box_adapter.mdx
@@ -17,16 +17,26 @@ the [official documentation](https://api.flutter.dev/flutter/widgets/SliverToBox
 
 ```json
 {
-  "type": "sliverToBoxAdapter",
-  "child": {
-    "type": "container",
-    "height": 200,
-    "color": "#FF5733",
+  "type": "sliverPadding",
+  "padding": {
+    "all": 16.0
+  },
+  "sliver": {
+    "type": "sliverToBoxAdapter",
     "child": {
-      "type": "center",
+      "type": "container",
+      "height": 150,
+      "color": "#4CAF50",
       "child": {
-        "type": "text",
-        "data": "I am a Box inside a Sliver!"
+        "type": "center",
+        "child": {
+          "type": "text",
+          "data": "I am a Box inside a SliverToBoxAdapter!",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
+        }
       }
     }
   }

--- a/docs/widgets/sliver_to_box_adapter.mdx
+++ b/docs/widgets/sliver_to_box_adapter.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SliverToBoxAdapter"
-description: "Documentation for SliverToBoxAdapter"
+description: "A sliver that contains a single box widget."
 ---
 
 The Stac SliverToBoxAdapter allows you to build a Flutter sliver-to-box-adapter widget using JSON. It creates a sliver that contains a single box widget.
@@ -18,9 +18,7 @@ the [official documentation](https://api.flutter.dev/flutter/widgets/SliverToBox
 ```json
 {
   "type": "sliverPadding",
-  "padding": {
-    "all": 16.0
-  },
+  "padding": 16,
   "sliver": {
     "type": "sliverToBoxAdapter",
     "child": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1249,7 +1249,7 @@
     },
     "subtitle": {
       "type": "text",
-      "data": "A Sliver To Box Adapter widget"
+      "data": "A sliver that contains a single box widget."
     },
     "style": "list",
     "onTap": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1240,6 +1240,30 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "iconType": "cupertino",
+      "icon": "app_fill"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Sliver To Box Adapter"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Material Design Sliver To Box Adapter widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_to_box_adapter_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "icon": "navigation"
     },
     "title": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1249,7 +1249,7 @@
     },
     "subtitle": {
       "type": "text",
-      "data": "A Material Design Sliver To Box Adapter widget"
+      "data": "A Sliver To Box Adapter widget"
     },
     "style": "list",
     "onTap": {

--- a/examples/stac_gallery/assets/json/sliver_to_box_adapter_example.json
+++ b/examples/stac_gallery/assets/json/sliver_to_box_adapter_example.json
@@ -5,9 +5,7 @@
         "slivers": [
             {
                 "type": "sliverPadding",
-                "padding": {
-                    "all": 16.0
-                },
+                "padding": 16.0,
                 "sliver": {
                     "type": "sliverToBoxAdapter",
                     "child": {

--- a/examples/stac_gallery/assets/json/sliver_to_box_adapter_example.json
+++ b/examples/stac_gallery/assets/json/sliver_to_box_adapter_example.json
@@ -1,0 +1,33 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverPadding",
+                "padding": {
+                    "all": 16.0
+                },
+                "sliver": {
+                    "type": "sliverToBoxAdapter",
+                    "child": {
+                        "type": "container",
+                        "height": 150,
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "I am a Box inside a SliverToBoxAdapter!",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverToBoxAdapterParser(),
     const StacOpacityParser(),
     const StacPlaceholderParser(),
     const StacAspectRatioParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_to_box_adapter/stac_sliver_to_box_adapter_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_to_box_adapter/stac_sliver_to_box_adapter_parser.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+class StacSliverToBoxAdapterParser extends StacParser<StacSliverToBoxAdapter> {
+  const StacSliverToBoxAdapterParser();
+
+  @override
+  String get type => WidgetType.sliverToBoxAdapter.name;
+
+  @override
+  StacSliverToBoxAdapter getModel(Map<String, dynamic> json) =>
+      StacSliverToBoxAdapter.fromJson(json);
+
+  @override
+  Widget parse(BuildContext context, StacSliverToBoxAdapter model) {
+    return SliverToBoxAdapter(child: model.child?.parse(context));
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -63,6 +63,7 @@ export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_sing
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_to_box_adapter/stac_sliver_to_box_adapter_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_spacer/stac_spacer_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_stack/stac_stack_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_switch/stac_switch_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,7 +207,7 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
-  /// Sliver app bar widget
+  /// Sliver to box adapter widget
   sliverToBoxAdapter,
 
   /// Spacer widget

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver app bar widget
+  sliverToBoxAdapter,
+
   /// Spacer widget
   spacer,
 

--- a/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
+++ b/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
@@ -22,9 +22,7 @@ part 'stac_sliver_to_box_adapter.g.dart';
 /// ```json
 /// {
 ///     "type": "sliverPadding",
-///     "padding": {
-///         "all": 16.0
-///     },
+///     "padding": 16.0,
 ///     "sliver": {
 ///         "type": "sliverToBoxAdapter",
 ///         "child": {

--- a/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
+++ b/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
@@ -9,10 +9,10 @@ part 'stac_sliver_to_box_adapter.g.dart';
 /// A sliver that contains a single box widget.
 ///
 /// {@tool snippet}
-/// Dart Example:
 /// ```dart
-/// const StacSliverToBoxAdapter(
-///   child: StacText(data: 'Hello'),
+/// const StacSliverPadding(
+///   padding: StacEdgeInsets.all(16),
+///   sliver: StacSliverToBoxAdapter(...),
 /// )
 /// ```
 /// {@end-tool}
@@ -21,11 +21,29 @@ part 'stac_sliver_to_box_adapter.g.dart';
 /// JSON Example:
 /// ```json
 /// {
-///   "type": "sliverToBoxAdapter",
-///   "child": {
-///     "type": "text",
-///     "data": "Hello"
-///   }
+///     "type": "sliverPadding",
+///     "padding": {
+///         "all": 16.0
+///     },
+///     "sliver": {
+///         "type": "sliverToBoxAdapter",
+///         "child": {
+///             "type": "container",
+///             "height": 150,
+///             "color": "#4CAF50",
+///             "child": {
+///                 "type": "center",
+///                 "child": {
+///                     "type": "text",
+///                     "data": "I am a Box inside a SliverToBoxAdapter!",
+///                     "style": {
+///                         "color": "#FFFFFF",
+///                         "fontWeight": "bold"
+///                     }
+///                 }
+///             }
+///         }
+///     }
 /// }
 /// ```
 /// {@end-tool}

--- a/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
+++ b/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.dart
@@ -1,0 +1,54 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_to_box_adapter.g.dart';
+
+/// A Stac model representing Flutter's [SliverToBoxAdapter] widget.
+///
+/// A sliver that contains a single box widget.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverToBoxAdapter(
+///   child: StacText(data: 'Hello'),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "sliverToBoxAdapter",
+///   "child": {
+///     "type": "text",
+///     "data": "Hello"
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverToBoxAdapter documentation](https://api.flutter.dev/flutter/widgets/SliverToBoxAdapter-class.html)
+@JsonSerializable()
+class StacSliverToBoxAdapter extends StacWidget {
+  /// Creates a [StacSliverToBoxAdapter].
+  const StacSliverToBoxAdapter({this.child});
+
+  /// The widget contained by this sliver.
+  final StacWidget? child;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.sliverToBoxAdapter.name;
+
+  /// Creates a [StacSliverToBoxAdapter] from a JSON map.
+  factory StacSliverToBoxAdapter.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverToBoxAdapterFromJson(json);
+
+  /// Converts this [StacSliverToBoxAdapter] instance to JSON.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverToBoxAdapterToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_to_box_adapter/stac_sliver_to_box_adapter.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_to_box_adapter.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverToBoxAdapter _$StacSliverToBoxAdapterFromJson(
+  Map<String, dynamic> json,
+) => StacSliverToBoxAdapter(
+  child: json['child'] == null
+      ? null
+      : StacWidget.fromJson(json['child'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$StacSliverToBoxAdapterToJson(
+  StacSliverToBoxAdapter instance,
+) => <String, dynamic>{
+  'child': instance.child?.toJson(),
+  'type': instance.type,
+};

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -67,6 +67,7 @@ export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
+export 'sliver_to_box_adapter/stac_sliver_to_box_adapter.dart';
 export 'spacer/stac_spacer.dart';
 export 'stack/stac_stack.dart';
 export 'switch/stac_switch.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverToBoxAdapter` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #422

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SliverToBoxAdapter support to enable embedding box widgets inside sliver-based layouts.

* **Documentation**
  * Added a new docs page with properties, usage guidance, and an example.

* **Examples**
  * Added a gallery entry and a runnable example demonstrating SliverToBoxAdapter usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->