### PR TITLE
feat: add stacSliverSafeArea widget, parser,example and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -123,6 +123,7 @@
                             "widgets/single_child_scroll_view",
                             "widgets/slider",
                             "widgets/sliver_app_bar",
+                            "widgets/sliver_safe_area",
                             "widgets/switch",
                             "widgets/tab_bar",
                             "widgets/text_button",

--- a/docs/widgets/sliver_safe_area.mdx
+++ b/docs/widgets/sliver_safe_area.mdx
@@ -1,0 +1,35 @@
+---
+title: "SliverSafeArea"
+description: "Documentation for SliverSafeArea"
+---
+
+The Stac SliverSafeArea allows you to build a Flutter sliver safe area widget using JSON.  
+To know more about the safe area widget in Flutter, refer to  
+the [official documentation](https://api.flutter.dev/flutter/widgets/SliverSafeArea-class.html).
+
+## Properties
+
+| Property | Type                    | Description                                                                 |
+|--------|-------------------------|-----------------------------------------------------------------------------|
+| left   | `bool?`                 | Whether to avoid intrusions on the left. Defaults to `true`.                |
+| top    | `bool?`                 | Whether to avoid intrusions at the top. Defaults to `true`.                 |
+| right  | `bool?`                 | Whether to avoid intrusions on the right. Defaults to `true`.               |
+| bottom | `bool?`                 | Whether to avoid intrusions at the bottom. Defaults to `true`.              |
+| minimum| `Map<String, dynamic>?` | Minimum padding to apply as edge insets.                                    |
+| sliver | `Map<String, dynamic>`  | The sliver widget below this widget in the tree. **(Required)**             |
+
+## Example JSON
+
+```json
+{
+  "type": "sliverSafeArea",
+  "top": true,
+  "sliver": {
+    "type": "sliverToBoxAdapter",
+    "child": {
+      "type": "text",
+      "data": "Hello World"
+    }
+  }
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1240,6 +1240,30 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "iconType": "cupertino",
+      "icon": "app_fill"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Sliver Safe Area"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Material Design Sliver Safe Area widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_safe_area_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "icon": "navigation"
     },
     "title": {

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1249,7 +1249,7 @@
     },
     "subtitle": {
       "type": "text",
-      "data": "A Material Design Sliver Safe Area widget"
+      "data": "A Sliver Safe Area widget"
     },
     "style": "list",
     "onTap": {

--- a/examples/stac_gallery/assets/json/sliver_safe_area_example.json
+++ b/examples/stac_gallery/assets/json/sliver_safe_area_example.json
@@ -1,0 +1,27 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverSafeArea",
+                "top": true,
+                "bottom": true,
+                "sliver": {
+                    "type": "sliverToBoxAdapter",
+                    "child": {
+                        "type": "container",
+                        "padding": {
+                            "type": "edgeInsets",
+                            "all": 16
+                        },
+                        "child": {
+                            "type": "text",
+                            "data": "Content inside SliverSafeArea"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverSafeAreaParser(),
     const StacOpacityParser(),
     const StacPlaceholderParser(),
     const StacAspectRatioParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart
@@ -16,7 +16,9 @@ class StacSliverSafeAreaParser extends StacParser<StacSliverSafeArea> {
 
   @override
   Widget parse(BuildContext context, StacSliverSafeArea model) {
-    final sliver = model.sliver.parse(context) ?? const SizedBox.shrink();
+    final sliver =
+        model.sliver.parse(context) ??
+        const SliverToBoxAdapter(child: SizedBox.shrink());
     return SliverSafeArea(
       left: model.left ?? true,
       top: model.top ?? true,

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac/src/parsers/foundation/geometry/stac_edge_insets_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+class StacSliverSafeAreaParser extends StacParser<StacSliverSafeArea> {
+  const StacSliverSafeAreaParser();
+
+  @override
+  String get type => WidgetType.sliverSafeArea.name;
+
+  @override
+  StacSliverSafeArea getModel(Map<String, dynamic> json) =>
+      StacSliverSafeArea.fromJson(json);
+
+  @override
+  Widget parse(BuildContext context, StacSliverSafeArea model) {
+    final sliver = model.sliver.parse(context) ?? const SizedBox.shrink();
+    return SliverSafeArea(
+      left: model.left ?? true,
+      top: model.top ?? true,
+      right: model.right ?? true,
+      bottom: model.bottom ?? true,
+      minimum: model.minimum?.parse ?? EdgeInsets.zero,
+      sliver: sliver,
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -63,6 +63,7 @@ export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_sing
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_spacer/stac_spacer_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_stack/stac_stack_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_switch/stac_switch_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver safe area widget
+  sliverSafeArea,
+
   /// Spacer widget
   spacer,
 

--- a/packages/stac_core/lib/widgets/sliver_safe_area/stac_sliver_safe_area.dart
+++ b/packages/stac_core/lib/widgets/sliver_safe_area/stac_sliver_safe_area.dart
@@ -1,0 +1,81 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_safe_area.g.dart';
+
+/// A Stac model representing Flutter's [SliverSafeArea] widget.
+///
+/// Insets its sliver child to avoid system UI intrusions
+/// such as status bar, notch, or navigation bar.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverSafeArea(
+///   top: true,
+///   sliver: StacSliverToBoxAdapter(
+///     child: StacText(data: 'Hello World'),
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "sliverSafeArea",
+///   "top": true,
+///   "sliver": {
+///     "type": "sliverToBoxAdapter",
+///     "child": {
+///       "type": "text",
+///       "data": "Hello World"
+///     }
+///   }
+/// }
+/// ```
+/// {@end-tool}
+@JsonSerializable()
+class StacSliverSafeArea extends StacWidget {
+  /// Creates a [StacSliverSafeArea].
+  const StacSliverSafeArea({
+    this.left,
+    this.top,
+    this.right,
+    this.bottom,
+    this.minimum,
+    required this.sliver,
+  });
+
+  /// Whether to avoid intrusions on the left.
+  final bool? left;
+
+  /// Whether to avoid intrusions at the top.
+  final bool? top;
+
+  /// Whether to avoid intrusions on the right.
+  final bool? right;
+
+  /// Whether to avoid intrusions at the bottom.
+  final bool? bottom;
+
+  /// Minimum padding to apply.
+  final StacEdgeInsets? minimum;
+
+  /// The sliver below this widget in the tree.
+  final StacWidget sliver;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.sliverSafeArea.name;
+
+  /// Creates a [StacSliverSafeArea] from JSON.
+  factory StacSliverSafeArea.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverSafeAreaFromJson(json);
+
+  /// Converts this instance to JSON.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverSafeAreaToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_safe_area/stac_sliver_safe_area.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_safe_area/stac_sliver_safe_area.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_safe_area.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverSafeArea _$StacSliverSafeAreaFromJson(Map<String, dynamic> json) =>
+    StacSliverSafeArea(
+      left: json['left'] as bool?,
+      top: json['top'] as bool?,
+      right: json['right'] as bool?,
+      bottom: json['bottom'] as bool?,
+      minimum: json['minimum'] == null
+          ? null
+          : StacEdgeInsets.fromJson(json['minimum']),
+      sliver: StacWidget.fromJson(json['sliver'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$StacSliverSafeAreaToJson(StacSliverSafeArea instance) =>
+    <String, dynamic>{
+      'left': instance.left,
+      'top': instance.top,
+      'right': instance.right,
+      'bottom': instance.bottom,
+      'minimum': instance.minimum?.toJson(),
+      'sliver': instance.sliver.toJson(),
+      'type': instance.type,
+    };

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -67,6 +67,7 @@ export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
+export 'sliver_safe_area/stac_sliver_safe_area.dart';
 export 'spacer/stac_spacer.dart';
 export 'stack/stac_stack.dart';
 export 'switch/stac_switch.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverSafeArea` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #420 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SliverSafeArea support for sliver-based layouts with configurable insets (left/top/right/bottom and minimum).

* **Documentation**
  * New SliverSafeArea doc page with properties, concise overview, example, and link to official Flutter docs.

* **Examples**
  * New gallery entry and runnable example demonstrating SliverSafeArea usage in a scrolling layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->