### PR TITLE
feat: add stacSliverGrid widget, parser, example, and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
                             "widgets/single_child_scroll_view",
                             "widgets/slider",
                             "widgets/sliver_app_bar",
+                            "widgets/sliver_grid",
                             "widgets/sliver_visibility",
                             "widgets/sliver_opacity",
                             "widgets/sliver_safe_area",

--- a/docs/widgets/sliver_grid.mdx
+++ b/docs/widgets/sliver_grid.mdx
@@ -1,0 +1,109 @@
+---
+title: "SliverGrid"
+description: "Documentation for SliverGrid"
+---
+
+The Stac **SliverGrid** allows you to build a Flutter `SliverGrid` widget using JSON.
+It displays its children in a two-dimensional scrollable grid within a sliver
+context.
+
+To learn more about Flutter’s `SliverGrid`, refer to the
+[official documentation](https://api.flutter.dev/flutter/widgets/SliverGrid-class.html).
+
+> ⚠️ **Note**
+>
+> `sliverGrid` must be placed **inside the `slivers` property of a `customScrollView`**.
+> Each child of a `sliverGrid` must be a **box widget** (for example `container`,
+> `card`, `column`, etc.), not another sliver.
+
+---
+
+## Properties
+
+| Property               | Type                          | Description                                                                 |
+|------------------------|-------------------------------|-----------------------------------------------------------------------------|
+| crossAxisCount         | `int?`                        | Number of children in the cross axis (e.g. number of columns).              |
+| mainAxisSpacing        | `double?`                     | Space between children in the main axis. Defaults to `0.0`.                 |
+| crossAxisSpacing       | `double?`                     | Space between children in the cross axis. Defaults to `0.0`.                |
+| childAspectRatio       | `double?`                     | Ratio of the cross-axis to the main-axis extent of each child. Defaults to `1.0`. |
+| mainAxisExtent         | `double?`                     | Fixed extent of each child in the main axis.                                |
+| addAutomaticKeepAlives | `bool?`                       | Whether to add automatic keep-alives for children. Defaults to `true`.      |
+| addRepaintBoundaries   | `bool?`                       | Whether to wrap children in repaint boundaries. Defaults to `true`.         |
+| addSemanticIndexes     | `bool?`                       | Whether to add semantic indexes for children. Defaults to `true`.           |
+| children               | `List<Map<String, dynamic>>?` | The list of widgets rendered as grid items.                                 |
+
+---
+
+## Example JSON
+
+```json
+{
+  "type": "sliverGrid",
+  "crossAxisCount": 2,
+  "mainAxisSpacing": 16,
+  "crossAxisSpacing": 16,
+  "childAspectRatio": 1,
+  "children": [
+    {
+      "type": "container",
+      "color": "#4CAF50",
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "text",
+          "data": "Grid Item 1",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
+        }
+      }
+    },
+    {
+      "type": "container",
+      "color": "#4CAF50",
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "text",
+          "data": "Grid Item 2",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
+        }
+      }
+    },
+    {
+      "type": "container",
+      "color": "#4CAF50",
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "text",
+          "data": "Grid Item 3",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
+        }
+      }
+    },
+    {
+      "type": "container",
+      "color": "#4CAF50",
+      "child": {
+        "type": "center",
+        "child": {
+          "type": "text",
+          "data": "Grid Item 4",
+          "style": {
+            "color": "#FFFFFF",
+            "fontWeight": "bold"
+          }
+        }
+      }
+    }
+  ]
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1245,6 +1245,30 @@
     },
     "title": {
       "type": "text",
+      "data": "Stac Sliver Grid"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A SliverGrid widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_grid_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
+      "iconType": "cupertino",
+      "icon": "app_fill"
+    },
+    "title": {
+      "type": "text",
       "data": "Stac Sliver Padding"
     },
     "subtitle": {

--- a/examples/stac_gallery/assets/json/sliver_grid_example.json
+++ b/examples/stac_gallery/assets/json/sliver_grid_example.json
@@ -1,0 +1,77 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverGrid",
+                "crossAxisCount": 2,
+                "mainAxisSpacing": 16,
+                "crossAxisSpacing": 16,
+                "childAspectRatio": 1,
+                "children": [
+                    {
+                        "type": "container",
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "Grid Item 1",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "container",
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "Grid Item 2",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "container",
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "Grid Item 3",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "type": "container",
+                        "color": "#4CAF50",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "Grid Item 4",
+                                "style": {
+                                    "color": "#FFFFFF",
+                                    "fontWeight": "bold"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverGridParser(),
     const StacSliverVisibilityParser(),
     const StacSliverOpacityParser(),
     const StacSliverSafeAreaParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_grid/stac_sliver_grid_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_grid/stac_sliver_grid_parser.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+class StacSliverGridParser extends StacParser<StacSliverGrid> {
+  const StacSliverGridParser();
+
+  @override
+  String get type => WidgetType.sliverGrid.name;
+
+  @override
+  StacSliverGrid getModel(Map<String, dynamic> json) =>
+      StacSliverGrid.fromJson(json);
+
+  @override
+  Widget parse(BuildContext context, StacSliverGrid model) {
+    final children = model.children?.parseList(context) ?? const <Widget>[];
+
+    return SliverGrid(
+      delegate: SliverChildListDelegate(
+        children,
+        addAutomaticKeepAlives: model.addAutomaticKeepAlives ?? true,
+        addRepaintBoundaries: model.addRepaintBoundaries ?? true,
+        addSemanticIndexes: model.addSemanticIndexes ?? true,
+      ),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: model.crossAxisCount ?? 1,
+        mainAxisSpacing: model.mainAxisSpacing ?? 0.0,
+        crossAxisSpacing: model.crossAxisSpacing ?? 0.0,
+        childAspectRatio: model.childAspectRatio ?? 1.0,
+        mainAxisExtent: model.mainAxisExtent,
+      ),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -63,6 +63,7 @@ export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_sing
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_grid/stac_sliver_grid_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_visibility/stac_sliver_visibility_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_opacity/stac_sliver_opacity_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver grid widget
+  sliverGrid,
+
   /// Sliver visibility widget
   sliverVisibility,
 

--- a/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.dart
+++ b/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.dart
@@ -1,0 +1,155 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/converters/double_converter.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_grid.g.dart';
+
+/// A Stac model representing Flutter's [SliverGrid] widget.
+///
+/// Displays its children in a two-dimensional scrollable grid
+/// within a sliver context.
+///
+/// This widget must be placed inside a [CustomScrollView]
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverGrid(
+///   crossAxisCount: 2,
+///   mainAxisSpacing: 12,
+///   crossAxisSpacing: 12,
+///   childAspectRatio: 1.0,
+///   children: [
+///     StacContainer(color: '#FF5722'),
+///     StacContainer(color: '#4CAF50'),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+// ```json
+// {
+//   "type": "sliverGrid",
+//   "crossAxisCount": 2,
+//   "mainAxisSpacing": 16,
+//   "crossAxisSpacing": 16,
+//   "childAspectRatio": 1,
+//   "children": [
+//     {
+//       "type": "container",
+//       "color": "#4CAF50",
+//       "child": {
+//         "type": "center",
+//         "child": {
+//           "type": "text",
+//           "data": "Grid Item 1",
+//           "style": {
+//             "color": "#FFFFFF",
+//             "fontWeight": "bold"
+//           }
+//         }
+//       }
+//     },
+//     {
+//       "type": "container",
+//       "color": "#4CAF50",
+//       "child": {
+//         "type": "center",
+//         "child": {
+//           "type": "text",
+//           "data": "Grid Item 2",
+//           "style": {
+//             "color": "#FFFFFF",
+//             "fontWeight": "bold"
+//           }
+//         }
+//       }
+//     }
+//   ]
+// }
+// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverGrid] documentation: https://api.flutter.dev/flutter/widgets/SliverGrid-class.html
+@JsonSerializable()
+class StacSliverGrid extends StacWidget {
+  /// Creates a [StacSliverGrid] with the given properties.
+  const StacSliverGrid({
+    this.crossAxisCount,
+    this.mainAxisSpacing,
+    this.crossAxisSpacing,
+    this.childAspectRatio,
+    this.mainAxisExtent,
+    this.addAutomaticKeepAlives,
+    this.addRepaintBoundaries,
+    this.addSemanticIndexes,
+    this.children,
+  });
+
+  /// The number of children in the cross axis.
+  ///
+  /// For example, a value of `2` creates a grid with two columns
+  /// when scrolling vertically.
+  final int? crossAxisCount;
+
+  /// The amount of space between children in the main axis.
+  ///
+  /// Defaults to `0.0`.
+  @DoubleConverter()
+  final double? mainAxisSpacing;
+
+  /// The amount of space between children in the cross axis.
+  ///
+  /// Defaults to `0.0`.
+  @DoubleConverter()
+  final double? crossAxisSpacing;
+
+  /// The ratio of the cross-axis to the main-axis extent of each child.
+  ///
+  /// Defaults to `1.0`.
+  @DoubleConverter()
+  final double? childAspectRatio;
+
+  /// The extent of each child in the main axis.
+  ///
+  /// If non-null, this forces children to have a fixed size in the
+  /// scrolling direction.
+  @DoubleConverter()
+  final double? mainAxisExtent;
+
+  /// Whether to add automatic keep-alives for the children.
+  ///
+  /// Defaults to `true` in Flutter's [SliverGrid].
+  final bool? addAutomaticKeepAlives;
+
+  /// Whether to wrap children in repaint boundaries.
+  ///
+  /// Defaults to `true` in Flutter's [SliverGrid].
+  final bool? addRepaintBoundaries;
+
+  /// Whether to add semantic indexes for the children.
+  ///
+  /// Defaults to `true` in Flutter's [SliverGrid].
+  final bool? addSemanticIndexes;
+
+  /// The widgets below this sliver in the tree.
+  ///
+  /// Each child is rendered as a grid item.
+  final List<StacWidget>? children;
+
+  /// Widget type identifier used by the Stac parser system.
+  @override
+  String get type => WidgetType.sliverGrid.name;
+
+  /// Creates a [StacSliverGrid] from a JSON map.
+  factory StacSliverGrid.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverGridFromJson(json);
+
+  /// Converts this [StacSliverGrid] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverGridToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.dart
+++ b/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.dart
@@ -30,47 +30,47 @@ part 'stac_sliver_grid.g.dart';
 ///
 /// {@tool snippet}
 /// JSON Example:
-// ```json
-// {
-//   "type": "sliverGrid",
-//   "crossAxisCount": 2,
-//   "mainAxisSpacing": 16,
-//   "crossAxisSpacing": 16,
-//   "childAspectRatio": 1,
-//   "children": [
-//     {
-//       "type": "container",
-//       "color": "#4CAF50",
-//       "child": {
-//         "type": "center",
-//         "child": {
-//           "type": "text",
-//           "data": "Grid Item 1",
-//           "style": {
-//             "color": "#FFFFFF",
-//             "fontWeight": "bold"
-//           }
-//         }
-//       }
-//     },
-//     {
-//       "type": "container",
-//       "color": "#4CAF50",
-//       "child": {
-//         "type": "center",
-//         "child": {
-//           "type": "text",
-//           "data": "Grid Item 2",
-//           "style": {
-//             "color": "#FFFFFF",
-//             "fontWeight": "bold"
-//           }
-//         }
-//       }
-//     }
-//   ]
-// }
-// ```
+/// ```json
+/// {
+///   "type": "sliverGrid",
+///   "crossAxisCount": 2,
+///   "mainAxisSpacing": 16,
+///   "crossAxisSpacing": 16,
+///   "childAspectRatio": 1,
+///   "children": [
+///     {
+///       "type": "container",
+///       "color": "#4CAF50",
+///       "child": {
+///         "type": "center",
+///         "child": {
+///           "type": "text",
+///           "data": "Grid Item 1",
+///           "style": {
+///             "color": "#FFFFFF",
+///             "fontWeight": "bold"
+///           }
+///         }
+///       }
+///     },
+///     {
+///       "type": "container",
+///       "color": "#4CAF50",
+///       "child": {
+///         "type": "center",
+///         "child": {
+///           "type": "text",
+///           "data": "Grid Item 2",
+///           "style": {
+///             "color": "#FFFFFF",
+///             "fontWeight": "bold"
+///           }
+///         }
+///       }
+///     }
+///   ]
+/// }
+/// ```
 /// {@end-tool}
 ///
 /// See also:

--- a/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_grid/stac_sliver_grid.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_grid.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverGrid _$StacSliverGridFromJson(
+  Map<String, dynamic> json,
+) => StacSliverGrid(
+  crossAxisCount: (json['crossAxisCount'] as num?)?.toInt(),
+  mainAxisSpacing: const DoubleConverter().fromJson(json['mainAxisSpacing']),
+  crossAxisSpacing: const DoubleConverter().fromJson(json['crossAxisSpacing']),
+  childAspectRatio: const DoubleConverter().fromJson(json['childAspectRatio']),
+  mainAxisExtent: const DoubleConverter().fromJson(json['mainAxisExtent']),
+  addAutomaticKeepAlives: json['addAutomaticKeepAlives'] as bool?,
+  addRepaintBoundaries: json['addRepaintBoundaries'] as bool?,
+  addSemanticIndexes: json['addSemanticIndexes'] as bool?,
+  children: (json['children'] as List<dynamic>?)
+      ?.map((e) => StacWidget.fromJson(e as Map<String, dynamic>))
+      .toList(),
+);
+
+Map<String, dynamic> _$StacSliverGridToJson(
+  StacSliverGrid instance,
+) => <String, dynamic>{
+  'crossAxisCount': instance.crossAxisCount,
+  'mainAxisSpacing': const DoubleConverter().toJson(instance.mainAxisSpacing),
+  'crossAxisSpacing': const DoubleConverter().toJson(instance.crossAxisSpacing),
+  'childAspectRatio': const DoubleConverter().toJson(instance.childAspectRatio),
+  'mainAxisExtent': const DoubleConverter().toJson(instance.mainAxisExtent),
+  'addAutomaticKeepAlives': instance.addAutomaticKeepAlives,
+  'addRepaintBoundaries': instance.addRepaintBoundaries,
+  'addSemanticIndexes': instance.addSemanticIndexes,
+  'children': instance.children?.map((e) => e.toJson()).toList(),
+  'type': instance.type,
+};

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -67,6 +67,7 @@ export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
+export 'sliver_grid/stac_sliver_grid.dart';
 export 'sliver_visibility/stac_sliver_visibility.dart';
 export 'sliver_opacity/stac_sliver_opacity.dart';
 export 'sliver_safe_area/stac_sliver_safe_area.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverGrid` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #416   

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SliverGrid widget support for building configurable scrollable grids inside CustomScrollView.

* **Documentation**
  * Added comprehensive SliverGrid docs covering properties, placement, and examples.

* **Examples**
  * Added a SliverGrid example and gallery entry demonstrating a two-column grid with styled items and navigation from the home gallery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->