### PR TITLE
feat: add stacSliverList widget, parser, example, and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
                             "widgets/single_child_scroll_view",
                             "widgets/slider",
                             "widgets/sliver_app_bar",
+                            "widgets/sliver_list",
                             "widgets/sliver_visibility",
                             "widgets/sliver_opacity",
                             "widgets/sliver_safe_area",

--- a/docs/widgets/sliver_list.mdx
+++ b/docs/widgets/sliver_list.mdx
@@ -1,0 +1,81 @@
+---
+title: "SliverList"
+description: "Documentation for SliverList"
+---
+
+The Stac SliverList allows you to build a Flutter sliver list widget using JSON.
+It displays its children in a linear, scrollable list within a sliver context.
+
+This widget must be used inside a `CustomScrollView`.
+To learn more about the SliverList widget in Flutter, refer to the
+[official documentation](https://api.flutter.dev/flutter/widgets/SliverList-class.html).
+
+## Properties
+
+| Property                 | Type                         | Description                                                                 |
+|--------------------------|------------------------------|-----------------------------------------------------------------------------|
+| children                 | `List<Map<String, dynamic>>?` | The list of widgets to display in the sliver list. Each child must be a box widget. |
+| addAutomaticKeepAlives   | `bool?`                      | Whether to add automatic keep-alives for the children. Defaults to `true`. |
+| addRepaintBoundaries     | `bool?`                      | Whether to wrap children in repaint boundaries. Defaults to `true`.        |
+| addSemanticIndexes       | `bool?`                      | Whether to add semantic indexes for the children. Defaults to `true`.      |
+| semanticIndexOffset      | `int?`                       | An offset added to each child’s semantic index. Useful when combining multiple slivers. |
+
+> **Note**
+>  
+> Children of `SliverList` must be **box widgets** (for example `Container`, `Text`, etc.).
+> To apply padding, opacity, or other sliver-level effects, wrap the `SliverList`
+> with widgets such as `SliverPadding` or `SliverOpacity`.
+
+## Example JSON
+
+```json
+{
+  "type": "scaffold",
+  "body": {
+    "type": "customScrollView",
+    "slivers": [
+      {
+        "type": "sliverList",
+        "children": [
+          {
+            "type": "container",
+            "height": 80,
+            "color": "primary",
+            "child": {
+              "type": "center",
+              "child": {
+                "type": "text",
+                "data": "List Item 1"
+              }
+            }
+          },
+          {
+            "type": "container",
+            "height": 80,
+            "color": "secondary",
+            "child": {
+              "type": "center",
+              "child": {
+                "type": "text",
+                "data": "List Item 2"
+              }
+            }
+          },
+          {
+            "type": "container",
+            "height": 80,
+            "color": "success",
+            "child": {
+              "type": "center",
+              "child": {
+                "type": "text",
+                "data": "List Item 3"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1288,6 +1288,29 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "icon": "list"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Sliver List"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Sliver List widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_list_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "iconType": "cupertino",
       "icon": "app_fill"
     },

--- a/examples/stac_gallery/assets/json/sliver_list_example.json
+++ b/examples/stac_gallery/assets/json/sliver_list_example.json
@@ -1,0 +1,37 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverList",
+                "children": [
+                    {
+                        "type": "container",
+                        "height": 80,
+                        "color": "primary",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "List Item 1"
+                            }
+                        }
+                    },
+                    {
+                        "type": "container",
+                        "height": 80,
+                        "color": "secondary",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "List Item 2"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverListParser(),
     const StacSliverVisibilityParser(),
     const StacSliverOpacityParser(),
     const StacSliverSafeAreaParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_list/stac_sliver_list_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_list/stac_sliver_list_parser.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+/// A Stac parser that builds a Flutter [SliverList] widget.
+class StacSliverListParser extends StacParser<StacSliverList> {
+  /// Creates a [StacSliverListParser].
+  const StacSliverListParser();
+
+  /// The widget type handled by this parser.
+  @override
+  String get type => WidgetType.sliverList.name;
+
+  /// Converts JSON into a [StacSliverList] model.
+  @override
+  StacSliverList getModel(Map<String, dynamic> json) =>
+      StacSliverList.fromJson(json);
+
+  /// Builds the Flutter [SliverList] widget.
+  @override
+  Widget parse(BuildContext context, StacSliverList model) {
+    final children = model.children?.parseList(context) ?? const <Widget>[];
+
+    return SliverList(
+      delegate: SliverChildListDelegate(
+        children,
+        addAutomaticKeepAlives: model.addAutomaticKeepAlives ?? true,
+        addRepaintBoundaries: model.addRepaintBoundaries ?? true,
+        addSemanticIndexes: model.addSemanticIndexes ?? true,
+        semanticIndexOffset: model.semanticIndexOffset ?? 0,
+      ),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -63,6 +63,7 @@ export 'package:stac/src/parsers/widgets/stac_single_child_scroll_view/stac_sing
 export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_list/stac_sliver_list_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_visibility/stac_sliver_visibility_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_opacity/stac_sliver_opacity_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver List widget
+  sliverList,
+
   /// Sliver visibility widget
   sliverVisibility,
 

--- a/packages/stac_core/lib/widgets/sliver_list/stac_sliver_list.dart
+++ b/packages/stac_core/lib/widgets/sliver_list/stac_sliver_list.dart
@@ -1,0 +1,123 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_list.g.dart';
+
+/// A Stac model representing Flutter's [SliverList] widget.
+///
+/// Displays its children in a linear scrollable list within
+/// a sliver context.
+///
+/// This widget must be placed inside a [CustomScrollView].
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverList(
+///   children: [
+///     StacText(data: 'Item 1'),
+///     StacText(data: 'Item 2'),
+///   ],
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+///   {
+///         "type": "sliverList",
+///         "children": [
+///           {
+///             "type": "container",
+///             "height": 80,
+///             "color": "primary",
+///             "child": {
+///               "type": "center",
+///               "child": {
+///                 "type": "text",
+///                 "data": "List Item 1"
+///               }
+///             }
+///           },
+///           {
+///             "type": "container",
+///             "height": 80,
+///             "color": "secondary",
+///             "child": {
+///               "type": "center",
+///               "child": {
+///                 "type": "text",
+///                 "data": "List Item 2"
+///               }
+///             }
+///           },
+///           {
+///             "type": "container",
+///             "height": 80,
+///             "color": "success",
+///             "child": {
+///               "type": "center",
+///               "child": {
+///                 "type": "text",
+///                 "data": "List Item 3"
+///               }
+///             }
+///           }
+///         ]
+///       }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverList] documentation:
+///    https://api.flutter.dev/flutter/widgets/SliverList-class.html
+@JsonSerializable()
+class StacSliverList extends StacWidget {
+  /// Creates a [StacSliverList] with the given properties.
+  const StacSliverList({
+    this.children,
+    this.addAutomaticKeepAlives,
+    this.addRepaintBoundaries,
+    this.addSemanticIndexes,
+    this.semanticIndexOffset,
+  });
+
+  /// The widgets below this sliver in the tree.
+  ///
+  /// Each child is rendered as a list item.
+  final List<StacWidget>? children;
+
+  /// Whether to add automatic keep-alives for the children.
+  ///
+  /// Defaults to `true` in Flutter's [SliverList].
+  final bool? addAutomaticKeepAlives;
+
+  /// Whether to wrap children in repaint boundaries.
+  ///
+  /// Defaults to `true` in Flutter's [SliverList].
+  final bool? addRepaintBoundaries;
+
+  /// Whether to add semantic indexes for the children.
+  ///
+  /// Defaults to `true` in Flutter's [SliverList].
+  final bool? addSemanticIndexes;
+
+  /// An offset added to each child’s semantic index.
+  ///
+  /// Useful when combining multiple slivers.
+  final int? semanticIndexOffset;
+
+  /// Widget type identifier used by the Stac parser system.
+  @override
+  String get type => WidgetType.sliverList.name;
+
+  /// Creates a [StacSliverList] from a JSON map.
+  factory StacSliverList.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverListFromJson(json);
+
+  /// Converts this [StacSliverList] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverListToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_list/stac_sliver_list.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_list/stac_sliver_list.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_list.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverList _$StacSliverListFromJson(Map<String, dynamic> json) =>
+    StacSliverList(
+      children: (json['children'] as List<dynamic>?)
+          ?.map((e) => StacWidget.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      addAutomaticKeepAlives: json['addAutomaticKeepAlives'] as bool?,
+      addRepaintBoundaries: json['addRepaintBoundaries'] as bool?,
+      addSemanticIndexes: json['addSemanticIndexes'] as bool?,
+      semanticIndexOffset: (json['semanticIndexOffset'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$StacSliverListToJson(StacSliverList instance) =>
+    <String, dynamic>{
+      'children': instance.children?.map((e) => e.toJson()).toList(),
+      'addAutomaticKeepAlives': instance.addAutomaticKeepAlives,
+      'addRepaintBoundaries': instance.addRepaintBoundaries,
+      'addSemanticIndexes': instance.addSemanticIndexes,
+      'semanticIndexOffset': instance.semanticIndexOffset,
+      'type': instance.type,
+    };

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -68,6 +68,7 @@ export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
 export 'sliver_visibility/stac_sliver_visibility.dart';
+export 'sliver_list/stac_sliver_list.dart';
 export 'sliver_opacity/stac_sliver_opacity.dart';
 export 'sliver_safe_area/stac_sliver_safe_area.dart';
 export 'sliver_padding/stac_sliver_padding.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverList` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #415    

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SliverList support to the JSON-driven UI, enabling efficient scrollable lists inside CustomScrollView with configurable keep-alives, repaint boundaries, semantic indexing, and index offsets.

* **Documentation**
  * Added documentation page describing SliverList usage, properties, and a JSON example.

* **Examples**
  * Added interactive gallery entry and JSON example showcasing a SliverList with sample list items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->