### PR TITLE
feat: add stacSliverFillRemaining widget, parser, example, and docume…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
                             "widgets/single_child_scroll_view",
                             "widgets/slider",
                             "widgets/sliver_app_bar",
+                            "widgets/sliver_fill_remaining",
                             "widgets/sliver_visibility",
                             "widgets/sliver_opacity",
                             "widgets/sliver_safe_area",

--- a/docs/widgets/sliver_fill_remaining.mdx
+++ b/docs/widgets/sliver_fill_remaining.mdx
@@ -1,0 +1,43 @@
+---
+title: "SliverFillRemaining"
+description: "Documentation for SliverFillRemaining"
+---
+
+The Stac SliverFillRemaining allows you to build a Flutter `SliverFillRemaining`
+widget using JSON.
+
+It fills the remaining space in a `CustomScrollView` after all preceding slivers
+have been laid out. This widget is commonly used for empty states, footers,
+or centered content.
+
+To learn more about the SliverFillRemaining widget in Flutter, refer to the
+[official documentation](https://api.flutter.dev/flutter/widgets/SliverFillRemaining-class.html).
+
+## Properties
+
+| Property        | Type                    | Description                                                                 |
+|-----------------|-------------------------|-----------------------------------------------------------------------------|
+| child           | `Map<String, dynamic>?` | The widget to display in the remaining space.                               |
+| hasScrollBody   | `bool`                  | Whether the child has a scrollable body. Defaults to `true`.                |
+| fillOverscroll  | `bool`                  | Whether the sliver should stretch to fill the overscroll area. Defaults to `false`. |
+
+> **Note**
+>
+> `SliverFillRemaining` is typically placed **at the end** of a `CustomScrollView`
+> to ensure it fills the remaining viewport space correctly.
+
+## Example JSON
+
+```json
+{
+  "type": "sliverFillRemaining",
+  "hasScrollBody": false,
+  "child": {
+    "type": "center",
+    "child": {
+      "type": "text",
+      "data": "This content fills the remaining space"
+    }
+  }
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1317,6 +1317,30 @@
     },
     "title": {
       "type": "text",
+      "data": "Stac Sliver Fill Remaining"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Sliver Fill Remaining widget."
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_fill_remaining_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
+      "iconType": "cupertino",
+      "icon": "app_fill"
+    },
+    "title": {
+      "type": "text",
       "data": "Stac Sliver Opacity"
     },
     "subtitle": {

--- a/examples/stac_gallery/assets/json/sliver_fill_remaining_example.json
+++ b/examples/stac_gallery/assets/json/sliver_fill_remaining_example.json
@@ -1,0 +1,19 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverFillRemaining",
+                "hasScrollBody": false,
+                "child": {
+                    "type": "center",
+                    "child": {
+                        "type": "text",
+                        "data": "This fills the remaining space"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverFillRemainingParser(),
     const StacSliverVisibilityParser(),
     const StacSliverOpacityParser(),
     const StacSliverSafeAreaParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_fill_remaining/stac_sliver_fill_remaining_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_fill_remaining/stac_sliver_fill_remaining_parser.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+/// A Stac parser that builds a Flutter [SliverFillRemaining] widget.
+class StacSliverFillRemainingParser
+    extends StacParser<StacSliverFillRemaining> {
+  /// Creates a [StacSliverFillRemainingParser].
+  const StacSliverFillRemainingParser();
+
+  /// The widget type handled by this parser.
+  @override
+  String get type => WidgetType.sliverFillRemaining.name;
+
+  /// Converts JSON into a [StacSliverFillRemaining] model.
+  @override
+  StacSliverFillRemaining getModel(Map<String, dynamic> json) =>
+      StacSliverFillRemaining.fromJson(json);
+
+  /// Builds the Flutter [SliverFillRemaining] widget.
+  @override
+  Widget parse(BuildContext context, StacSliverFillRemaining model) {
+    return SliverFillRemaining(
+      hasScrollBody: model.hasScrollBody ?? true,
+      fillOverscroll: model.fillOverscroll ?? false,
+      child: model.child?.parse(context),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -64,6 +64,7 @@ export 'package:stac/src/parsers/widgets/stac_sized_box/stac_sized_box_parser.da
 export 'package:stac/src/parsers/widgets/stac_slider/stac_slider_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_visibility/stac_sliver_visibility_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_fill_remaining/stac_sliver_fill_remaining_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_opacity/stac_sliver_opacity_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_padding/stac_sliver_padding_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver fill remaining widget
+  sliverFillRemaining,
+
   /// Sliver visibility widget
   sliverVisibility,
 

--- a/packages/stac_core/lib/widgets/sliver_fill_remaining/stac_sliver_fill_remaining.dart
+++ b/packages/stac_core/lib/widgets/sliver_fill_remaining/stac_sliver_fill_remaining.dart
@@ -1,0 +1,80 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_fill_remaining.g.dart';
+
+/// A Stac model representing Flutter's [SliverFillRemaining] widget.
+///
+/// Fills the remaining space in a `CustomScrollView` after all preceding
+/// slivers have been laid out.
+///
+/// This widget is commonly used to display empty states, footers, or
+/// centered content that should expand to occupy the remaining viewport.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverFillRemaining(
+///   hasScrollBody: false,
+///   child: StacCenter(
+///     child: StacText(data: 'No items available'),
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "sliverFillRemaining",
+///   "hasScrollBody": false,
+///   "child": {
+///     "type": "center",
+///     "child": {
+///       "type": "text",
+///       "data": "No items available"
+///     }
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverFillRemaining documentation]
+///    (https://api.flutter.dev/flutter/widgets/SliverFillRemaining-class.html)
+@JsonSerializable()
+class StacSliverFillRemaining extends StacWidget {
+  /// Creates a [StacSliverFillRemaining] with the given properties.
+  const StacSliverFillRemaining({
+    this.child,
+    this.hasScrollBody,
+    this.fillOverscroll,
+  });
+
+  /// The widget to display in the remaining space of the scroll view.
+  final StacWidget? child;
+
+  /// Whether the [child] has a scrollable body.
+  ///
+  /// Defaults to `true`.
+  final bool? hasScrollBody;
+
+  /// Whether the sliver should stretch to fill the over-scroll area.
+  ///
+  /// Defaults to `false`.
+  final bool? fillOverscroll;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.sliverFillRemaining.name;
+
+  /// Creates a [StacSliverFillRemaining] from a JSON map.
+  factory StacSliverFillRemaining.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverFillRemainingFromJson(json);
+
+  /// Converts this [StacSliverFillRemaining] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverFillRemainingToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_fill_remaining/stac_sliver_fill_remaining.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_fill_remaining/stac_sliver_fill_remaining.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_fill_remaining.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverFillRemaining _$StacSliverFillRemainingFromJson(
+  Map<String, dynamic> json,
+) => StacSliverFillRemaining(
+  child: json['child'] == null
+      ? null
+      : StacWidget.fromJson(json['child'] as Map<String, dynamic>),
+  hasScrollBody: json['hasScrollBody'] as bool?,
+  fillOverscroll: json['fillOverscroll'] as bool?,
+);
+
+Map<String, dynamic> _$StacSliverFillRemainingToJson(
+  StacSliverFillRemaining instance,
+) => <String, dynamic>{
+  'child': instance.child?.toJson(),
+  'hasScrollBody': instance.hasScrollBody,
+  'fillOverscroll': instance.fillOverscroll,
+  'type': instance.type,
+};

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -67,6 +67,7 @@ export 'single_child_scroll_view/stac_single_child_scroll_view.dart';
 export 'sized_box/stac_sized_box.dart';
 export 'slider/stac_slider.dart';
 export 'sliver_app_bar/stac_sliver_app_bar.dart';
+export 'sliver_fill_remaining/stac_sliver_fill_remaining.dart';
 export 'sliver_visibility/stac_sliver_visibility.dart';
 export 'sliver_opacity/stac_sliver_opacity.dart';
 export 'sliver_safe_area/stac_sliver_safe_area.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverFillRemaining` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #429 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SliverFillRemaining so UIs can fill remaining scrollable space with configurable scroll/body behavior.

* **Documentation**
  * Added comprehensive documentation describing properties, placement, behavior, and usage examples.

* **Examples**
  * Added an interactive gallery example and a new home-screen entry to demonstrate SliverFillRemaining in action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->