### PR TITLE
feat: add stacSliverOffstage widget, parser, example, and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
                             "widgets/single_child_scroll_view",
                             "widgets/slider",
                             "widgets/sliver_app_bar",
+                            "widgets/sliver_off_stage",
                             "widgets/sliver_visibility",
                             "widgets/sliver_opacity",
                             "widgets/sliver_safe_area",

--- a/docs/widgets/sliver_off_stage.mdx
+++ b/docs/widgets/sliver_off_stage.mdx
@@ -1,0 +1,42 @@
+---
+title: "SliverOffstage"
+description: "Documentation for SliverOffstage"
+---
+
+The Stac SliverOffstage allows you to build a Flutter `SliverOffstage`
+widget using JSON.
+
+It conditionally hides or shows a sliver without removing it from the
+sliver tree. When the sliver is offstage, it is not painted and does not
+occupy any space in the scroll view.
+
+To learn more about the SliverOffstage widget in Flutter, refer to the
+[official documentation](https://api.flutter.dev/flutter/widgets/SliverOffstage-class.html).
+
+## Properties
+
+| Property | Type                    | Description                                                       |
+|--------|-------------------------|-------------------------------------------------------------------|
+| offstage | `bool`                | Whether the sliver should be hidden. Defaults to `true`.          |
+| sliver  | `Map<String, dynamic>?` | The sliver widget to conditionally hide or show.                  |
+
+> **Note**
+>
+> `SliverOffstage` only accepts **sliver widgets** as its child.
+> To hide regular widgets, use `Offstage` instead.
+
+## Example JSON
+
+```json
+{
+  "type": "sliverOffstage",
+  "offstage": false,
+  "sliver": {
+    "type": "sliverToBoxAdapter",
+    "child": {
+      "type": "text",
+      "data": "This sliver is visible"
+    }
+  }
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1288,6 +1288,29 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "icon": "visibility"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Sliver Offstage"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Sliver Offstage widget"
+    },
+    "style": "list",
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/sliver_off_stage_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "iconType": "cupertino",
       "icon": "app_fill"
     },

--- a/examples/stac_gallery/assets/json/sliver_off_stage_example.json
+++ b/examples/stac_gallery/assets/json/sliver_off_stage_example.json
@@ -1,0 +1,42 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "customScrollView",
+        "slivers": [
+            {
+                "type": "sliverOffstage",
+                "offstage": false,
+                "sliver": {
+                    "type": "sliverToBoxAdapter",
+                    "child": {
+                        "type": "container",
+                        "height": 120,
+                        "color": "primary",
+                        "child": {
+                            "type": "center",
+                            "child": {
+                                "type": "text",
+                                "data": "This sliver can be hidden"
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "type": "sliverToBoxAdapter",
+                "child": {
+                    "type": "container",
+                    "height": 120,
+                    "color": "primary",
+                    "child": {
+                        "type": "center",
+                        "child": {
+                            "type": "text",
+                            "data": "Main Content"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -114,6 +114,7 @@ class StacService {
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),
+    const StacSliverOffstageParser(),
     const StacSliverVisibilityParser(),
     const StacSliverOpacityParser(),
     const StacSliverSafeAreaParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_sliver_off_stage/stac_sliver_off_stage_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_sliver_off_stage/stac_sliver_off_stage_parser.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+/// A Stac parser that builds a Flutter [SliverOffstage] widget.
+class StacSliverOffstageParser extends StacParser<StacSliverOffstage> {
+  /// Creates a [StacSliverOffstageParser].
+  const StacSliverOffstageParser();
+
+  /// The widget type handled by this parser.
+  @override
+  String get type => WidgetType.sliverOffstage.name;
+
+  /// Converts JSON into a [StacSliverOffstage] model.
+  @override
+  StacSliverOffstage getModel(Map<String, dynamic> json) =>
+      StacSliverOffstage.fromJson(json);
+
+  /// Builds the Flutter [SliverOffstage] widget.
+  @override
+  Widget parse(BuildContext context, StacSliverOffstage model) {
+    return SliverOffstage(
+      offstage: model.offstage ?? true,
+      sliver: model.sliver?.parse(context),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -66,6 +66,7 @@ export 'package:stac/src/parsers/widgets/stac_sliver_app_bar/stac_sliver_app_bar
 export 'package:stac/src/parsers/widgets/stac_sliver_visibility/stac_sliver_visibility_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_opacity/stac_sliver_opacity_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_safe_area/stac_sliver_safe_area_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_sliver_off_stage/stac_sliver_off_stage_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_padding/stac_sliver_padding_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_sliver_to_box_adapter/stac_sliver_to_box_adapter_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_spacer/stac_spacer_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -207,6 +207,9 @@ enum WidgetType {
   /// Sliver app bar widget
   sliverAppBar,
 
+  /// Sliver Offstage widget
+  sliverOffstage,
+
   /// Sliver visibility widget
   sliverVisibility,
 

--- a/packages/stac_core/lib/widgets/sliver_off_stage/stac_sliver_off_stage.dart
+++ b/packages/stac_core/lib/widgets/sliver_off_stage/stac_sliver_off_stage.dart
@@ -1,0 +1,79 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_sliver_off_stage.g.dart';
+
+/// A Stac model representing Flutter's [SliverOffstage] widget.
+///
+/// Conditionally shows or hides a sliver without removing it from
+/// the sliver tree.
+///
+/// When [offstage] is set to `true`, the sliver is not painted and does
+/// not occupy any space in the scroll view, while still remaining part
+/// of the widget tree. This is useful for toggling the visibility of
+/// slivers without rebuilding the entire scroll view.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// const StacSliverOffstage(
+///   offstage: false,
+///   sliver: StacSliverToBoxAdapter(
+///     child: StacText(data: 'This sliver is visible'),
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "sliverOffstage",
+///   "offstage": false,
+///   "sliver": {
+///     "type": "sliverToBoxAdapter",
+///     "child": {
+///       "type": "text",
+///       "data": "This sliver is visible"
+///     }
+///   }
+/// }
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///  * Flutter's [SliverOffstage documentation]
+///    (https://api.flutter.dev/flutter/widgets/SliverOffstage-class.html)
+@JsonSerializable()
+class StacSliverOffstage extends StacWidget {
+  /// Creates a [StacSliverOffstage] with the given properties.
+  const StacSliverOffstage({this.offstage, this.sliver});
+
+  /// Whether the sliver should be hidden.
+  ///
+  /// When set to `true`, the sliver is not painted and does not take up
+  /// any space in the scroll view.
+  ///
+  /// Defaults to `true`.
+  final bool? offstage;
+
+  /// The sliver widget to conditionally hide or show.
+  ///
+  /// This must be a **sliver widget**, such as [StacSliverList],
+  /// [StacSliverGrid], or [StacSliverToBoxAdapter].
+  final StacWidget? sliver;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.sliverOffstage.name;
+
+  /// Creates a [StacSliverOffstage] from a JSON map.
+  factory StacSliverOffstage.fromJson(Map<String, dynamic> json) =>
+      _$StacSliverOffstageFromJson(json);
+
+  /// Converts this [StacSliverOffstage] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacSliverOffstageToJson(this);
+}

--- a/packages/stac_core/lib/widgets/sliver_off_stage/stac_sliver_off_stage.g.dart
+++ b/packages/stac_core/lib/widgets/sliver_off_stage/stac_sliver_off_stage.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_sliver_off_stage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacSliverOffstage _$StacSliverOffstageFromJson(Map<String, dynamic> json) =>
+    StacSliverOffstage(
+      offstage: json['offstage'] as bool?,
+      sliver: json['sliver'] == null
+          ? null
+          : StacWidget.fromJson(json['sliver'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$StacSliverOffstageToJson(StacSliverOffstage instance) =>
+    <String, dynamic>{
+      'offstage': instance.offstage,
+      'sliver': instance.sliver?.toJson(),
+      'type': instance.type,
+    };

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -70,6 +70,7 @@ export 'sliver_app_bar/stac_sliver_app_bar.dart';
 export 'sliver_visibility/stac_sliver_visibility.dart';
 export 'sliver_opacity/stac_sliver_opacity.dart';
 export 'sliver_safe_area/stac_sliver_safe_area.dart';
+export 'sliver_off_stage/stac_sliver_off_stage.dart';
 export 'sliver_padding/stac_sliver_padding.dart';
 export 'sliver_to_box_adapter/stac_sliver_to_box_adapter.dart';
 export 'spacer/stac_spacer.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacSliverOffstage` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #431  

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the SliverOffstage widget, enabling conditional visibility of sliver widgets within scrollable content without affecting layout
  * Included comprehensive documentation and practical usage examples
  * Made the widget accessible through the navigation menu

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->