### PR TITLE
feat: add stacOffstage widget, parser, example, and documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,6 +89,7 @@
                             "widgets/icon",
                             "widgets/image",
                             "widgets/opacity",
+                            "widgets/offstage",
                             "widgets/placeholder",
                             "widgets/visibility"
                         ]

--- a/docs/widgets/offstage.mdx
+++ b/docs/widgets/offstage.mdx
@@ -1,0 +1,41 @@
+---
+title: "Offstage"
+description: "Documentation for Offstage"
+---
+
+The Stac Offstage allows you to build a Flutter `Offstage` widget using JSON.
+
+It controls whether a widget is visible without removing it from the widget tree.
+When the widget is offstage, it is not painted, does not occupy any space in the
+layout, and does not participate in hit testing.
+
+This widget is useful for conditionally showing or hiding content while preserving
+widget state.
+
+To learn more about the Offstage widget in Flutter, refer to the
+[official documentation](https://api.flutter.dev/flutter/widgets/Offstage-class.html).
+
+## Properties
+
+| Property  | Type                    | Description                                           |
+|----------|-------------------------|-------------------------------------------------------|
+| offstage | `bool`                  | Whether the child should be hidden. Defaults to `true`. |
+| child    | `Map<String, dynamic>?` | The widget below this widget in the tree.             |
+
+> **Note**
+>
+> Unlike `Visibility`, `Offstage` completely removes the widget from layout
+> while keeping it in the widget tree.
+
+## Example JSON
+
+```json
+{
+  "type": "offstage",
+  "offstage": false,
+  "child": {
+    "type": "text",
+    "data": "This widget is visible"
+  }
+}
+```

--- a/examples/stac_gallery/assets/json/home_screen.json
+++ b/examples/stac_gallery/assets/json/home_screen.json
@@ -1382,6 +1382,28 @@
     "type": "listTile",
     "leading": {
       "type": "icon",
+      "icon": "disabled_visible"
+    },
+    "title": {
+      "type": "text",
+      "data": "Stac Offstage"
+    },
+    "subtitle": {
+      "type": "text",
+      "data": "A Stac Offstage widget"
+    },
+    "onTap": {
+      "actionType": "navigate",
+      "widgetJson": {
+        "type": "exampleScreen",
+        "assetPath": "assets/json/offstage_example.json"
+      }
+    }
+  },
+  {
+    "type": "listTile",
+    "leading": {
+      "type": "icon",
       "icon": "apartment"
     },
     "title": {

--- a/examples/stac_gallery/assets/json/offstage_example.json
+++ b/examples/stac_gallery/assets/json/offstage_example.json
@@ -1,0 +1,22 @@
+{
+    "type": "scaffold",
+    "body": {
+        "type": "center",
+        "child": {
+            "type": "offstage",
+            "offstage": false,
+            "child": {
+                "type": "container",
+                "height": 120,
+                "color": "primary",
+                "child": {
+                    "type": "center",
+                    "child": {
+                        "type": "text",
+                        "data": "I am visible"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -111,6 +111,7 @@ class StacService {
     const StacLinearProgressIndicatorParser(),
     const StacHeroParser(),
     const StacRadioParser(),
+    const StacOffstageParser(),
     const StacRadioGroupParser(),
     const StacSliderParser(),
     const StacSliverAppBarParser(),

--- a/packages/stac/lib/src/parsers/widgets/stac_offstage/stac_offstage_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_offstage/stac_offstage_parser.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:stac/src/parsers/core/stac_widget_parser.dart';
+import 'package:stac_core/stac_core.dart';
+import 'package:stac_framework/stac_framework.dart';
+
+/// A Stac parser that builds a Flutter [Offstage] widget.
+class StacOffstageParser extends StacParser<StacOffstage> {
+  /// Creates a [StacOffstageParser].
+  const StacOffstageParser();
+
+  /// The widget type handled by this parser.
+  @override
+  String get type => WidgetType.offstage.name;
+
+  /// Converts JSON into a [StacOffstage] model.
+  @override
+  StacOffstage getModel(Map<String, dynamic> json) =>
+      StacOffstage.fromJson(json);
+
+  /// Builds the Flutter [Offstage] widget.
+  @override
+  Widget parse(BuildContext context, StacOffstage model) {
+    return Offstage(
+      offstage: model.offstage ?? true,
+      child: model.child?.parse(context),
+    );
+  }
+}

--- a/packages/stac/lib/src/parsers/widgets/widgets.dart
+++ b/packages/stac/lib/src/parsers/widgets/widgets.dart
@@ -47,6 +47,7 @@ export 'package:stac/src/parsers/widgets/stac_list_tile/stac_list_tile_parser.da
 export 'package:stac/src/parsers/widgets/stac_list_view/stac_list_view_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_network_widget/stac_network_widget_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_opacity/stac_opacity_parser.dart';
+export 'package:stac/src/parsers/widgets/stac_offstage/stac_offstage_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_outlined_button/stac_outlined_button_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_padding/stac_padding_parser.dart';
 export 'package:stac/src/parsers/widgets/stac_page_view/stac_page_view_parser.dart';

--- a/packages/stac_core/lib/foundation/specifications/widget_type.dart
+++ b/packages/stac_core/lib/foundation/specifications/widget_type.dart
@@ -153,6 +153,9 @@ enum WidgetType {
   /// Network widget
   networkWidget,
 
+  /// Offstage widget
+  offstage,
+
   /// Opacity widget
   opacity,
 

--- a/packages/stac_core/lib/widgets/offstage/stac_offstage.dart
+++ b/packages/stac_core/lib/widgets/offstage/stac_offstage.dart
@@ -1,0 +1,90 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:stac_core/core/stac_widget.dart';
+import 'package:stac_core/foundation/foundation.dart';
+
+part 'stac_offstage.g.dart';
+
+/// A Stac model representing Flutter's [Offstage] widget.
+///
+/// This widget controls whether a child widget is visible without
+/// removing it from the widget tree.
+///
+/// When [offstage] is set to `true`, the child is not painted, does not
+/// occupy any space in the layout, and is excluded from hit testing,
+/// while still preserving the widget's state.
+///
+/// This widget is useful for conditionally showing or hiding UI content
+/// without rebuilding or disposing of the underlying widget.
+///
+/// {@tool snippet}
+/// Dart Example:
+/// ```dart
+/// StacOffstage(
+///   offstage: false,
+///   child: StacContainer(
+///     height: 100,
+///     color: 'primary',
+///     child: StacCenter(
+///       child: StacText(data: 'I am visible'),
+///     ),
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+/// JSON Example:
+/// ```json
+/// {
+///   "type": "offstage",
+///   "offstage": false,
+///   "child": {
+///     "type": "container",
+///     "height": 100,
+///     "color": "primary",
+///     "child": {
+///       "type": "center",
+///       "child": {
+///         "type": "text",
+///         "data": "I am visible"
+///       }
+///     }
+///   }
+/// }
+/// ```
+/// {@end-tool}
+@JsonSerializable()
+class StacOffstage extends StacWidget {
+  /// Creates a [StacOffstage].
+  ///
+  /// The [offstage] parameter controls whether the [child] widget
+  /// is hidden. The [child] parameter defines the widget to show
+  /// or hide.
+  const StacOffstage({this.offstage, this.child});
+
+  /// Whether the child widget should be hidden.
+  ///
+  /// When set to `true`, the child is not painted, does not take up
+  /// any space in the layout, and does not participate in hit testing.
+  ///
+  /// Defaults to `true`.
+  final bool? offstage;
+
+  /// The widget below this widget in the tree.
+  ///
+  /// This widget remains part of the widget tree even when it is
+  /// hidden, allowing its state to be preserved.
+  final StacWidget? child;
+
+  /// Widget type identifier.
+  @override
+  String get type => WidgetType.offstage.name;
+
+  /// Creates a [StacOffstage] from a JSON map.
+  factory StacOffstage.fromJson(Map<String, dynamic> json) =>
+      _$StacOffstageFromJson(json);
+
+  /// Converts this [StacOffstage] instance to a JSON map.
+  @override
+  Map<String, dynamic> toJson() => _$StacOffstageToJson(this);
+}

--- a/packages/stac_core/lib/widgets/offstage/stac_offstage.g.dart
+++ b/packages/stac_core/lib/widgets/offstage/stac_offstage.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stac_offstage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StacOffstage _$StacOffstageFromJson(Map<String, dynamic> json) => StacOffstage(
+  offstage: json['offstage'] as bool?,
+  child: json['child'] == null
+      ? null
+      : StacWidget.fromJson(json['child'] as Map<String, dynamic>),
+);
+
+Map<String, dynamic> _$StacOffstageToJson(StacOffstage instance) =>
+    <String, dynamic>{
+      'offstage': instance.offstage,
+      'child': instance.child?.toJson(),
+      'type': instance.type,
+    };

--- a/packages/stac_core/lib/widgets/widgets.dart
+++ b/packages/stac_core/lib/widgets/widgets.dart
@@ -50,6 +50,7 @@ export 'list_tile/stac_list_tile.dart';
 export 'list_view/stac_list_view.dart';
 export 'network_widget/stac_network_widget.dart';
 export 'opacity/stac_opacity.dart';
+export 'offstage/stac_offstage.dart';
 export 'outlined_button/stac_outlined_button.dart';
 export 'padding/stac_padding.dart';
 export 'page_view/stac_page_view.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR introduces support for `stacOffstage` by adding a new widget model and its corresponding parser.

## Related Issues

<!--- List the related issues to this PR -->
Closes #433   

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Offstage widget support, allowing developers to conditionally hide/show content while preserving widget state. The widget is removed from layout calculations but remains in the widget tree.

* **Documentation**
  * Added dedicated documentation page explaining Offstage behavior and use cases.
  * Added interactive gallery example demonstrating Offstage widget in action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->