### PR TITLE
refactor: Centralize cache configuration to `Stac.initialize` and set networkFirst` as default cache strategy.

### DIFF
--- a/docs/concepts/caching.mdx
+++ b/docs/concepts/caching.mdx
@@ -3,7 +3,7 @@ title: "Caching & Offline Support"
 description: "Learn how Stac intelligently caches screens for offline access, faster loading, and smarter network usage"
 ---
 
-Stac includes a powerful caching system that stores screens locally, enabling offline access, instant loading, and more efficient network usage. The caching layer works automatically with the `Stac` widget and can be customized for different use cases.
+Stac includes a powerful caching system that stores screens locally, enabling offline access, instant loading, and more efficient network usage. The caching layer works automatically with the `Stac` widget and is configured globally during initialization.
 
 ## How Caching Works
 
@@ -14,42 +14,72 @@ When you use the `Stac` widget to fetch screens from Stac Cloud:
 3. **Version Tracking**: Each cached screen stores its version number, enabling smart updates
 4. **Background Updates**: Fresh data can be fetched in the background without blocking the UI
 
+## Global Configuration
+
+Configure caching once during app initialization. This applies to all `Stac` widgets and `StacAppTheme`:
+
+```dart
+await Stac.initialize(
+  options: defaultStacOptions,
+  cacheConfig: StacCacheConfig(
+    strategy: StacCacheStrategy.networkFirst, // default
+    maxAge: Duration(days: 30),
+  ),
+);
+```
+
 ## Cache Strategies
 
 Stac provides five caching strategies to fit different use cases:
 
-### 1. Optimistic (Default)
+### 1. Network First (Default)
 
-Returns cached data immediately while fetching updates in the background. Best for fast perceived performance.
+Always tries the network first, falls back to cache if network fails. **This is the default strategy.**
 
 ```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.optimistic,
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.networkFirst,
 )
 ```
 
 **Behavior:**
-- ✅ Returns cached data instantly (even if expired)
+- ✅ Always fetches fresh data first
+- ✅ Falls back to cache on network error
+- ✅ Ensures latest content when online
+- 🌐 Requires network for best experience
+
+**Best for:** Server-driven UI where users should see the latest content, real-time data, frequently changing screens.
+
+### 2. Optimistic
+
+Returns cached data immediately while fetching updates in the background.
+
+```dart
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.optimistic,
+)
+```
+
+**Behavior:**
+- ✅ Returns cached data instantly
 - ✅ Fetches fresh data in background
 - ✅ Updates cache for next load
 - ⚡ Fastest perceived loading
 
 **Best for:** UI layouts, content screens, any screen where instant loading matters more than showing the absolute latest data.
 
-### 2. Cache First
+<Warning>
+  With optimistic caching, users see outdated content until the next app launch after you deploy updates. Consider using `networkFirst` if immediate updates are important.
+</Warning>
+
+### 3. Cache First
 
 Uses cached data if available and valid, only fetches from network when cache is invalid or missing.
 
 ```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(hours: 24),
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheFirst,
+  maxAge: Duration(hours: 24),
 )
 ```
 
@@ -61,37 +91,13 @@ Stac(
 
 **Best for:** Offline-first apps, content that doesn't change frequently, reducing network usage.
 
-### 3. Network First
-
-Always tries the network first, falls back to cache if network fails.
-
-```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.networkFirst,
-  ),
-)
-```
-
-**Behavior:**
-- ✅ Always fetches fresh data first
-- ✅ Falls back to cache on network error
-- ✅ Ensures latest content when online
-- 🌐 Requires network for best experience
-
-**Best for:** Real-time data, frequently changing content, screens where freshness is critical.
-
 ### 4. Cache Only
 
 Only uses cached data, never makes network requests. Throws an error if no cache exists.
 
 ```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheOnly,
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheOnly,
 )
 ```
 
@@ -108,11 +114,8 @@ Stac(
 Always fetches from network, never uses or updates cache.
 
 ```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.networkOnly,
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.networkOnly,
 )
 ```
 
@@ -124,16 +127,33 @@ Stac(
 
 **Best for:** Sensitive data that shouldn't be cached, real-time dashboards, authentication screens.
 
-## Cache Configuration
+## Configuration Options
 
 ### StacCacheConfig Properties
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `strategy` | `StacCacheStrategy` | `optimistic` | The caching strategy to use |
-| `maxAge` | `Duration?` | `null` | Maximum age before cache is considered expired. `null` means no time-based expiration |
-| `refreshInBackground` | `bool` | `true` | Whether to fetch fresh data in background when cache is valid |
-| `staleWhileRevalidate` | `bool` | `false` | Whether to use expired cache while fetching fresh data |
+| `strategy` | `StacCacheStrategy` | `networkFirst` | The caching strategy to use |
+| `maxAge` | `Duration?` | `null` | Maximum age before cache is considered stale. `null` means no time-based expiration |
+| `refreshInBackground` | `bool` | `true` | Whether to fetch fresh data in background when showing cached content |
+
+### Presets
+
+Use built-in presets for common scenarios:
+
+```dart
+// For offline-first apps
+cacheConfig: StacCacheConfig.offlineFirst
+
+// For real-time data (always fetch)
+cacheConfig: StacCacheConfig.realTime
+
+// For fast loading with background updates
+cacheConfig: StacCacheConfig.fastWithUpdates
+
+// For static content (7-day cache)
+cacheConfig: StacCacheConfig.staticContent
+```
 
 ### Setting Cache Duration
 
@@ -141,30 +161,21 @@ Control how long cached data remains valid:
 
 ```dart
 // Cache valid for 1 hour
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(hours: 1),
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheFirst,
+  maxAge: Duration(hours: 1),
 )
 
 // Cache valid for 7 days
-Stac(
-  routeName: '/settings',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(days: 7),
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheFirst,
+  maxAge: Duration(days: 7),
 )
 
 // Cache never expires (only version-based updates)
-Stac(
-  routeName: '/static-page',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: null, // No time-based expiration
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheFirst,
+  maxAge: null, // No time-based expiration
 )
 ```
 
@@ -173,13 +184,10 @@ Stac(
 Keep cache fresh without blocking the UI:
 
 ```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(hours: 1),
-    refreshInBackground: true, // Fetch updates silently
-  ),
+cacheConfig: StacCacheConfig(
+  strategy: StacCacheStrategy.cacheFirst,
+  maxAge: Duration(hours: 1),
+  refreshInBackground: true, // Fetch updates silently
 )
 ```
 
@@ -189,33 +197,13 @@ When `refreshInBackground` is `true`:
 - Cache is updated for next load
 - User sees instant loading with eventual consistency
 
-### Stale While Revalidate
-
-Show expired cache while fetching fresh data:
-
-```dart
-Stac(
-  routeName: '/home',
-  cacheConfig: StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(hours: 1),
-    staleWhileRevalidate: true, // Use expired cache while fetching
-  ),
-)
-```
-
-This is useful when:
-- You prefer showing something over a loading spinner
-- Content staleness is acceptable for a brief period
-- Network is slow or unreliable
-
 ## Strategy Comparison
 
 | Strategy | Initial Load | Subsequent Load | Offline Support | Best For |
 |----------|--------------|-----------------|-----------------|----------|
-| `optimistic` | Network → Cache | Cache (bg update) | ✅ Yes | Fast UX |
+| `networkFirst` | Network | Network (cache fallback) | ⚠️ Fallback only | Fresh data (default) |
+| `optimistic` | Cache or Network | Cache (bg update) | ✅ Yes | Fast UX |
 | `cacheFirst` | Cache or Network | Cache | ✅ Yes | Offline apps |
-| `networkFirst` | Network | Network (cache fallback) | ⚠️ Fallback only | Fresh data |
 | `cacheOnly` | Cache only | Cache only | ✅ Yes | Offline mode |
 | `networkOnly` | Network only | Network only | ❌ No | Sensitive data |
 
@@ -230,3 +218,20 @@ Stac tracks version numbers for each cached screen. When you deploy updates to S
 
 This ensures users get updates without manual intervention while maintaining fast loading times.
 
+## Clearing Cache
+
+Clear cached screens programmatically:
+
+```dart
+// Clear a specific screen
+await StacCloud.clearScreenCache('/home');
+
+// Clear all cached screens
+await StacCloud.clearAllCache();
+
+// Clear a specific theme
+await StacCloud.clearThemeCache('dark');
+
+// Clear all cached themes
+await StacCloud.clearAllThemeCache();
+```

--- a/docs/concepts/caching.mdx
+++ b/docs/concepts/caching.mdx
@@ -137,24 +137,6 @@ cacheConfig: StacCacheConfig(
 | `maxAge` | `Duration?` | `null` | Maximum age before cache is considered stale. `null` means no time-based expiration |
 | `refreshInBackground` | `bool` | `true` | Whether to fetch fresh data in background when showing cached content |
 
-### Presets
-
-Use built-in presets for common scenarios:
-
-```dart
-// For offline-first apps
-cacheConfig: StacCacheConfig.offlineFirst
-
-// For real-time data (always fetch)
-cacheConfig: StacCacheConfig.realTime
-
-// For fast loading with background updates
-cacheConfig: StacCacheConfig.fastWithUpdates
-
-// For static content (7-day cache)
-cacheConfig: StacCacheConfig.staticContent
-```
-
 ### Setting Cache Duration
 
 Control how long cached data remains valid:

--- a/packages/stac/CHANGELOG.md
+++ b/packages/stac/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-dev.1
+
+- **BREAKING**: Refactored caching to use global configuration via `Stac.initialize()`. See [Caching Docs](https://docs.stac.dev/concepts/caching) for migration guide.
+
 ## 1.2.0
 
 - Added screen caching and offline support

--- a/packages/stac/README.md
+++ b/packages/stac/README.md
@@ -40,8 +40,8 @@ This approach separates your app's presentation layer from its business logic, e
 - 🎛 Actions & navigation: Control routes and API calls from the backend.
 - 📝 Forms & validation: Built-in form state and validation rules.
 - 🎨 Theming: Brand and layout via JSON with Stac Theme.
-- � Caching: Intelligent screen caching with configurable strategies.
-- �🔌 Extensible: Add custom widgets, actions, and native integrations.
+- 💾 Caching: Intelligent screen caching with configurable strategies.
+- 🔌 Extensible: Add custom widgets, actions, and native integrations.
 
 ## Documentation
 

--- a/packages/stac/README.md
+++ b/packages/stac/README.md
@@ -40,7 +40,8 @@ This approach separates your app's presentation layer from its business logic, e
 - 🎛 Actions & navigation: Control routes and API calls from the backend.
 - 📝 Forms & validation: Built-in form state and validation rules.
 - 🎨 Theming: Brand and layout via JSON with Stac Theme.
-- 🔌 Extensible: Add custom widgets, actions, and native integrations.
+- � Caching: Intelligent screen caching with configurable strategies.
+- �🔌 Extensible: Add custom widgets, actions, and native integrations.
 
 ## Documentation
 

--- a/packages/stac/lib/src/framework/stac.dart
+++ b/packages/stac/lib/src/framework/stac.dart
@@ -65,15 +65,16 @@ typedef StacErrorWidgetBuilder =
 ///
 /// By default, Stac uses an optimistic caching strategy that returns
 /// cached data immediately while fetching updates in the background.
+/// Configure caching globally during initialization:
 ///
 /// ```dart
-/// Stac(
-///   routeName: '/home',
+/// await Stac.initialize(
+///   options: StacOptions(projectId: 'your-project-id'),
 ///   cacheConfig: StacCacheConfig(
 ///     strategy: StacCacheStrategy.cacheFirst,
 ///     maxAge: Duration(hours: 24),
 ///   ),
-/// )
+/// );
 /// ```
 ///
 /// ## Custom Loading and Error States
@@ -105,16 +106,12 @@ class Stac extends StatelessWidget {
   /// Optionally provide [loadingWidget] and [errorWidget] to customize
   /// the loading and error states. If not provided, defaults are used.
   ///
-  /// The [cacheConfig] controls caching behavior. Defaults to optimistic
-  /// caching which returns cached data immediately and updates in background.
+  /// Cache behavior is configured globally via [Stac.initialize].
   const Stac({
     super.key,
     required this.routeName,
     this.loadingWidget,
     this.errorWidget,
-    this.cacheConfig = const StacCacheConfig(
-      strategy: StacCacheStrategy.optimistic,
-    ),
   });
 
   /// The route name identifying the screen to fetch from Stac Cloud.
@@ -133,32 +130,6 @@ class Stac extends StatelessWidget {
   ///
   /// If `null`, an empty [SizedBox] is shown on error.
   final Widget? errorWidget;
-
-  /// Configuration for cache behavior.
-  ///
-  /// Controls cache strategy, TTL, background refresh, and more.
-  ///
-  /// Defaults to optimistic caching strategy.
-  ///
-  /// Example:
-  /// ```dart
-  /// Stac(
-  ///   routeName: '/home',
-  ///   cacheConfig: StacCacheConfig(
-  ///     maxAge: Duration(hours: 24),
-  ///     strategy: StacCacheStrategy.optimistic,
-  ///   ),
-  /// )
-  /// ```
-  ///
-  /// Or use presets:
-  /// ```dart
-  /// Stac(
-  ///   routeName: '/home',
-  ///   cacheConfig: StacCacheConfig.cacheFirst,
-  /// )
-  /// ```
-  final StacCacheConfig cacheConfig;
 
   /// Initializes Stac with the provided configuration.
   ///
@@ -191,6 +162,9 @@ class Stac extends StatelessWidget {
   /// - [errorWidgetBuilder]: Custom builder for error widgets shown when
   ///   parsing fails.
   ///
+  /// - [cacheConfig]: Global cache configuration for all Stac widgets and
+  ///   StacCloud calls. Defaults to optimistic caching if not provided.
+  ///
   /// ## Example
   ///
   /// ```dart
@@ -213,6 +187,7 @@ class Stac extends StatelessWidget {
     bool showErrorWidgets = true,
     bool logStackTraces = true,
     StacErrorWidgetBuilder? errorWidgetBuilder,
+    StacCacheConfig? cacheConfig,
   }) async {
     return StacService.initialize(
       options: options,
@@ -223,6 +198,7 @@ class Stac extends StatelessWidget {
       showErrorWidgets: showErrorWidgets,
       logStackTraces: logStackTraces,
       errorWidgetBuilder: errorWidgetBuilder,
+      cacheConfig: cacheConfig,
     );
   }
 
@@ -232,7 +208,6 @@ class Stac extends StatelessWidget {
       routeName: routeName,
       loadingWidget: loadingWidget,
       errorWidget: errorWidget,
-      cacheConfig: cacheConfig,
     );
   }
 
@@ -346,13 +321,11 @@ class _StacView extends StatelessWidget {
     required this.routeName,
     this.loadingWidget,
     this.errorWidget,
-    required this.cacheConfig,
   });
 
   final String routeName;
   final Widget? loadingWidget;
   final Widget? errorWidget;
-  final StacCacheConfig cacheConfig;
 
   @override
   Widget build(BuildContext context) {
@@ -362,10 +335,7 @@ class _StacView extends StatelessWidget {
     }
 
     return FutureBuilder<Response?>(
-      future: StacCloud.fetchScreen(
-        routeName: routeName,
-        cacheConfig: cacheConfig,
-      ),
+      future: StacCloud.fetchScreen(routeName: routeName),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return loadingWidget ?? const _LoadingWidget();

--- a/packages/stac/lib/src/framework/stac.dart
+++ b/packages/stac/lib/src/framework/stac.dart
@@ -63,8 +63,8 @@ typedef StacErrorWidgetBuilder =
 ///
 /// ## Caching
 ///
-/// By default, Stac uses an optimistic caching strategy that returns
-/// cached data immediately while fetching updates in the background.
+/// By default, Stac uses a network-first caching strategy that always
+/// fetches the latest content, falling back to cache when offline.
 /// Configure caching globally during initialization:
 ///
 /// ```dart
@@ -163,7 +163,7 @@ class Stac extends StatelessWidget {
   ///   parsing fails.
   ///
   /// - [cacheConfig]: Global cache configuration for all Stac widgets and
-  ///   StacCloud calls. Defaults to optimistic caching if not provided.
+  ///   StacCloud calls. Defaults to networkFirst strategy if not provided.
   ///
   /// ## Example
   ///

--- a/packages/stac/lib/src/framework/stac_service.dart
+++ b/packages/stac/lib/src/framework/stac_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide ErrorWidgetBuilder;
 import 'package:flutter/services.dart';
 import 'package:stac/src/framework/stac.dart';
+import 'package:stac/src/models/stac_cache_config.dart';
 import 'package:stac/src/framework/stac_error.dart';
 import 'package:stac/src/framework/stac_registry.dart';
 import 'package:stac/src/parsers/actions/stac_form_validate/stac_form_validate_parser.dart';
@@ -161,6 +162,12 @@ class StacService {
   // Optional global parse-error widget builder supplied by the app.
   static StacErrorWidgetBuilder? _errorWidgetBuilder;
 
+  // Default cache configuration for all Stac widgets and StacCloud calls.
+  static StacCacheConfig _defaultCacheConfig = const StacCacheConfig(
+    strategy: StacCacheStrategy.networkFirst,
+  );
+  static StacCacheConfig get defaultCacheConfig => _defaultCacheConfig;
+
   static Future<void> initialize({
     StacOptions? options,
     List<StacParser> parsers = const [],
@@ -170,8 +177,12 @@ class StacService {
     bool showErrorWidgets = true,
     bool logStackTraces = true,
     StacErrorWidgetBuilder? errorWidgetBuilder,
+    StacCacheConfig? cacheConfig,
   }) async {
     _options = options;
+    if (cacheConfig != null) {
+      _defaultCacheConfig = cacheConfig;
+    }
     _parsers.addAll(parsers);
     _actionParsers.addAll(actionParsers);
     StacRegistry.instance.registerAll(_parsers, override);

--- a/packages/stac/lib/src/models/stac_cache_config.dart
+++ b/packages/stac/lib/src/models/stac_cache_config.dart
@@ -40,19 +40,6 @@ enum StacCacheStrategy {
 ///   ),
 /// );
 /// ```
-///
-/// ## Using Presets
-///
-/// ```dart
-/// // For offline-first apps
-/// cacheConfig: StacCacheConfig.offlineFirst
-///
-/// // For real-time data
-/// cacheConfig: StacCacheConfig.realTime
-///
-/// // For fast loading with background updates
-/// cacheConfig: StacCacheConfig.fastWithUpdates
-/// ```
 class StacCacheConfig {
   /// Creates a [StacCacheConfig] instance.
   const StacCacheConfig({

--- a/packages/stac/lib/src/models/stac_cache_config.dart
+++ b/packages/stac/lib/src/models/stac_cache_config.dart
@@ -1,23 +1,26 @@
 /// Defines different cache strategies for Stac screens.
+///
+/// These strategies follow industry-standard patterns used in service workers
+/// (Workbox), HTTP caching (RFC 5861), and data fetching libraries (SWR).
 enum StacCacheStrategy {
-  /// Always fetch from network, update cache in background.
-  /// Best for real-time data.
+  /// Always fetch from network, use cache as fallback on failure.
+  /// Best for: real-time data, frequently changing content.
   networkFirst,
 
   /// Use cache if available and valid, fallback to network.
-  /// Best for offline-first apps.
+  /// Best for: offline-first apps, read-heavy content.
   cacheFirst,
 
-  /// Return cache immediately, update in background.
-  /// Best for fast loading with eventual consistency.
+  /// Return cache immediately, update in background (stale-while-revalidate).
+  /// Best for: fast loading with eventual consistency.
   optimistic,
 
   /// Only use cache, never fetch from network.
-  /// Best for offline-only mode.
+  /// Best for: offline-only mode, airplane mode.
   cacheOnly,
 
   /// Only use network, never cache.
-  /// Best for sensitive data that shouldn't be cached.
+  /// Best for: sensitive data that shouldn't persist.
   networkOnly,
 }
 
@@ -26,74 +29,126 @@ enum StacCacheStrategy {
 /// This class allows fine-grained control over how screens are cached,
 /// when they expire, and how updates are handled.
 ///
-/// Example:
+/// ## Basic Usage
+///
 /// ```dart
-/// Stac(
-///   routeName: '/home',
+/// await Stac.initialize(
+///   options: StacOptions(...),
 ///   cacheConfig: StacCacheConfig(
 ///     maxAge: Duration(hours: 24),
 ///     strategy: StacCacheStrategy.optimistic,
 ///   ),
-/// )
+/// );
+/// ```
+///
+/// ## Using Presets
+///
+/// ```dart
+/// // For offline-first apps
+/// cacheConfig: StacCacheConfig.offlineFirst
+///
+/// // For real-time data
+/// cacheConfig: StacCacheConfig.realTime
+///
+/// // For fast loading with background updates
+/// cacheConfig: StacCacheConfig.fastWithUpdates
 /// ```
 class StacCacheConfig {
   /// Creates a [StacCacheConfig] instance.
   const StacCacheConfig({
     this.maxAge,
-    this.strategy = StacCacheStrategy.optimistic,
+    this.strategy = StacCacheStrategy.networkFirst,
     this.refreshInBackground = true,
-    this.staleWhileRevalidate = false,
   });
 
-  /// Maximum age of cached data before it's considered expired.
+  // ─────────────────────────────────────────────────────────────────────────
+  // Presets
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /// Preset for offline-first apps.
   ///
-  /// When `null`, cache never expires based on time (only version updates matter).
+  /// Uses cache whenever available, only fetches from network when cache
+  /// is missing or expired. Refreshes cache in background.
+  static const offlineFirst = StacCacheConfig(
+    strategy: StacCacheStrategy.cacheFirst,
+    refreshInBackground: true,
+  );
+
+  /// Preset for real-time data.
+  ///
+  /// Always fetches from network, uses cache only as fallback on failure.
+  static const realTime = StacCacheConfig(
+    strategy: StacCacheStrategy.networkFirst,
+    refreshInBackground: false,
+  );
+
+  /// Preset for fast loading with eventual consistency.
+  ///
+  /// Shows cached content immediately while fetching updates in background.
+  /// This is the default strategy.
+  static const fastWithUpdates = StacCacheConfig(
+    strategy: StacCacheStrategy.optimistic,
+    refreshInBackground: true,
+  );
+
+  /// Preset for static content that rarely changes.
+  ///
+  /// Uses cache with a long TTL (7 days), refreshes in background.
+  static const staticContent = StacCacheConfig(
+    strategy: StacCacheStrategy.cacheFirst,
+    maxAge: Duration(days: 7),
+    refreshInBackground: true,
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Properties
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /// Maximum age of cached data before it's considered stale.
+  ///
+  /// When `null`, cache validity is determined by version only.
   ///
   /// Examples:
-  /// - `Duration(hours: 1)` - Cache expires after 1 hour
-  /// - `Duration(days: 7)` - Cache expires after 7 days
-  /// - `Duration(minutes: 30)` - Cache expires after 30 minutes
+  /// - `Duration(hours: 1)` - Cache is stale after 1 hour
+  /// - `Duration(days: 7)` - Cache is stale after 7 days
   final Duration? maxAge;
 
   /// The caching strategy to use.
   ///
-  /// Defaults to [StacCacheStrategy.optimistic].
+  /// Defaults to [StacCacheStrategy.networkFirst].
   final StacCacheStrategy strategy;
 
-  /// Whether to refresh cache in the background when data is stale but valid.
+  /// Whether to refresh cache in the background.
   ///
-  /// Only applies to [StacCacheStrategy.optimistic] and [StacCacheStrategy.cacheFirst].
+  /// When `true` (default): Shows cached data immediately, fetches updates
+  /// in background for the next load.
   ///
-  /// When `true`: Shows cached data, fetches updates in background
-  /// When `false`: Only updates when cache is completely invalid
+  /// When `false`: Only fetches when cache is invalid or missing.
+  ///
+  /// Only applies to [StacCacheStrategy.optimistic] and
+  /// [StacCacheStrategy.cacheFirst].
   final bool refreshInBackground;
 
-  /// Use stale cache while revalidating (fetch in background).
-  ///
-  /// When `true`: Even expired cache will be shown while fetching fresh data.
-  /// When `false`: Expired cache is treated as invalid.
-  ///
-  /// Useful for providing instant UI even when cache is expired.
-  final bool staleWhileRevalidate;
+  // ─────────────────────────────────────────────────────────────────────────
+  // Methods
+  // ─────────────────────────────────────────────────────────────────────────
 
   /// Creates a copy of this config with the given fields replaced.
   StacCacheConfig copyWith({
     Duration? maxAge,
     StacCacheStrategy? strategy,
     bool? refreshInBackground,
-    bool? staleWhileRevalidate,
   }) {
     return StacCacheConfig(
       maxAge: maxAge ?? this.maxAge,
       strategy: strategy ?? this.strategy,
       refreshInBackground: refreshInBackground ?? this.refreshInBackground,
-      staleWhileRevalidate: staleWhileRevalidate ?? this.staleWhileRevalidate,
     );
   }
 
   @override
   String toString() {
-    return 'StacCacheConfig(maxAge: $maxAge, strategy: $strategy, refreshInBackground: $refreshInBackground, staleWhileRevalidate: $staleWhileRevalidate)';
+    return 'StacCacheConfig(maxAge: $maxAge, strategy: $strategy, refreshInBackground: $refreshInBackground)';
   }
 
   @override
@@ -103,17 +158,11 @@ class StacCacheConfig {
     return other is StacCacheConfig &&
         other.maxAge == maxAge &&
         other.strategy == strategy &&
-        other.refreshInBackground == refreshInBackground &&
-        other.staleWhileRevalidate == staleWhileRevalidate;
+        other.refreshInBackground == refreshInBackground;
   }
 
   @override
   int get hashCode {
-    return Object.hash(
-      maxAge,
-      strategy,
-      refreshInBackground,
-      staleWhileRevalidate,
-    );
+    return Object.hash(maxAge, strategy, refreshInBackground);
   }
 }

--- a/packages/stac/lib/src/models/stac_cache_config.dart
+++ b/packages/stac/lib/src/models/stac_cache_config.dart
@@ -61,49 +61,6 @@ class StacCacheConfig {
     this.refreshInBackground = true,
   });
 
-  // ─────────────────────────────────────────────────────────────────────────
-  // Presets
-  // ─────────────────────────────────────────────────────────────────────────
-
-  /// Preset for offline-first apps.
-  ///
-  /// Uses cache whenever available, only fetches from network when cache
-  /// is missing or expired. Refreshes cache in background.
-  static const offlineFirst = StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    refreshInBackground: true,
-  );
-
-  /// Preset for real-time data.
-  ///
-  /// Always fetches from network, uses cache only as fallback on failure.
-  static const realTime = StacCacheConfig(
-    strategy: StacCacheStrategy.networkFirst,
-    refreshInBackground: false,
-  );
-
-  /// Preset for fast loading with eventual consistency.
-  ///
-  /// Shows cached content immediately while fetching updates in background.
-  /// This is the default strategy.
-  static const fastWithUpdates = StacCacheConfig(
-    strategy: StacCacheStrategy.optimistic,
-    refreshInBackground: true,
-  );
-
-  /// Preset for static content that rarely changes.
-  ///
-  /// Uses cache with a long TTL (7 days), refreshes in background.
-  static const staticContent = StacCacheConfig(
-    strategy: StacCacheStrategy.cacheFirst,
-    maxAge: Duration(days: 7),
-    refreshInBackground: true,
-  );
-
-  // ─────────────────────────────────────────────────────────────────────────
-  // Properties
-  // ─────────────────────────────────────────────────────────────────────────
-
   /// Maximum age of cached data before it's considered stale.
   ///
   /// When `null`, cache validity is determined by version only.

--- a/packages/stac/lib/src/services/stac_cloud.dart
+++ b/packages/stac/lib/src/services/stac_cloud.dart
@@ -50,24 +50,18 @@ class StacCloud {
 
   /// Fetches an artifact from Stac Cloud with intelligent caching.
   ///
-  /// The [cacheConfig] parameter controls caching behavior:
-  /// - Strategy: How to handle cache vs network
-  /// - maxAge: How long cache is valid
-  /// - refreshInBackground: Whether to update stale cache in background
-  /// - staleWhileRevalidate: Use expired cache while fetching fresh data
-  ///
-  /// Defaults to [StacCacheConfig.optimistic] if not provided.
+  /// Uses the global cache configuration from [StacService.defaultCacheConfig],
+  /// which is set via [Stac.initialize].
   static Future<Response?> _fetchArtifact({
     required StacArtifactType artifactType,
     required String artifactName,
-    StacCacheConfig cacheConfig = const StacCacheConfig(
-      strategy: StacCacheStrategy.optimistic,
-    ),
   }) async {
     final options = StacService.options;
     if (options == null) {
       throw Exception('StacOptions is not set');
     }
+
+    final cacheConfig = StacService.defaultCacheConfig;
 
     // Handle network-only strategy
     if (cacheConfig.strategy == StacCacheStrategy.networkOnly) {
@@ -140,23 +134,12 @@ class StacCloud {
 
   /// Fetches a screen from Stac Cloud with intelligent caching.
   ///
-  /// The [cacheConfig] parameter controls caching behavior:
-  /// - Strategy: How to handle cache vs network
-  /// - maxAge: How long cache is valid
-  /// - refreshInBackground: Whether to update stale cache in background
-  /// - staleWhileRevalidate: Use expired cache while fetching fresh data
-  ///
-  /// Defaults to [StacCacheConfig.optimistic] if not provided.
-  static Future<Response?> fetchScreen({
-    required String routeName,
-    StacCacheConfig cacheConfig = const StacCacheConfig(
-      strategy: StacCacheStrategy.optimistic,
-    ),
-  }) async {
+  /// Uses the global cache configuration from [StacService.defaultCacheConfig],
+  /// which is set via [Stac.initialize].
+  static Future<Response?> fetchScreen({required String routeName}) async {
     return _fetchArtifact(
       artifactType: StacArtifactType.screen,
       artifactName: routeName,
-      cacheConfig: cacheConfig,
     );
   }
 
@@ -213,8 +196,8 @@ class StacCloud {
         saveToCache: true,
       );
     } catch (e) {
-      // Network failed, use stale cache if available and staleWhileRevalidate is true
-      if (cachedArtifact != null && config.staleWhileRevalidate) {
+      // Network failed, use stale cache if available
+      if (cachedArtifact != null) {
         Log.d(
           'StacCloud: Using stale cache for ${artifactType.name} $artifactName due to network error',
         );
@@ -232,10 +215,9 @@ class StacCloud {
     required bool isCacheValid,
     required StacCacheConfig config,
   }) async {
-    // If cache exists and is valid (or staleWhileRevalidate is true)
-    if (cachedArtifact != null &&
-        (isCacheValid || config.staleWhileRevalidate)) {
-      // Update in background if configured
+    // If cache exists (show stale cache while revalidating)
+    if (cachedArtifact != null) {
+      // Update in background if configured or cache is stale
       if (config.refreshInBackground || !isCacheValid) {
         _fetchAndUpdateArtifactInBackground(
           artifactType: artifactType,
@@ -246,7 +228,7 @@ class StacCloud {
       return _buildArtifactCacheResponse(artifactType, cachedArtifact);
     }
 
-    // No valid cache, must fetch from network
+    // No cache, must fetch from network
     return _fetchArtifactFromNetwork(
       artifactType: artifactType,
       artifactName: artifactName,
@@ -369,23 +351,12 @@ class StacCloud {
 
   /// Fetches a theme from Stac Cloud with intelligent caching.
   ///
-  /// The [cacheConfig] parameter controls caching behavior:
-  /// - Strategy: How to handle cache vs network
-  /// - maxAge: How long cache is valid
-  /// - refreshInBackground: Whether to update stale cache in background
-  /// - staleWhileRevalidate: Use expired cache while fetching fresh data
-  ///
-  /// Defaults to [StacCacheConfig.optimistic] if not provided.
-  static Future<Response?> fetchTheme({
-    required String themeName,
-    StacCacheConfig cacheConfig = const StacCacheConfig(
-      strategy: StacCacheStrategy.optimistic,
-    ),
-  }) async {
+  /// Uses the global cache configuration from [StacService.defaultCacheConfig],
+  /// which is set via [Stac.initialize].
+  static Future<Response?> fetchTheme({required String themeName}) async {
     return _fetchArtifact(
       artifactType: StacArtifactType.theme,
       artifactName: themeName,
-      cacheConfig: cacheConfig,
     );
   }
 


### PR DESCRIPTION
## Description

This PR cleans up how caching works in Stac by moving everything to one place and making the default behavior more predictable.

Instead of configuring cache in multiple spots, caching is now set globally during `Stac.initialize`, and all `Stac` widgets and `StacCloud` calls follow the same rules by default.

### What’s inside
- Cache config is now centralized in `Stac.initialize`
- `networkFirst` is the new default strategy so users always get fresh data when online
- Removed duplicated per widget cache handling
- Simplified cache flow inside framework and services
- Updated docs to match the new behavior

### Why this change
Caching logic was scattered and sometimes confusing. This makes it:
- Easier to understand
- Easier to configure
- More aligned with server driven UI use cases
- Less error prone and more consistent across the app

### Migration notes
- If you were not setting cache config explicitly, your app will now use `networkFirst`
- You can still override cache behavior when needed

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Caching is now configured globally at initialization; per-widget/ per-call cache configuration has been removed (migration required).

* **New Features**
  * Default caching strategy changed to “Network First” (Optimistic remains available).
  * Added programmatic cache-clearing APIs for screens and themes.

* **Documentation**
  * Caching guide updated with global setup, strategy descriptions, examples, cache-duration semantics, and clearing cache instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->