### PR TITLE
feat: add constructors for StacImage widget to support asset, network and file sources

### DIFF
--- a/docs/widgets/image.mdx
+++ b/docs/widgets/image.mdx
@@ -9,39 +9,60 @@ To learn more about the equivalent Flutter widgets and their properties, refer t
 
 ## Properties
 
-| Property              | Type                  | Description                                                                                               |
-|-----------------------|-----------------------|-----------------------------------------------------------------------------------------------------------|
-| `src`                 | `String`              | The source of the image. For example, a URL for network images, file path for file images, or asset path. |
-| `alignment`           | `StacAlignment`       | The alignment of the image within its container. Defaults to `StacAlignment.center`.                      |
-| `imageType`           | `StacImageType`       | The type of the image source: `file`, `network`, or `asset`. Defaults to `StacImageType.network`.         |
-| `color`               | `StacColor`           | The color to blend with the image.                                                                        |
-| `width`               | `double`              | The width of the image in logical pixels.                                                                 |
-| `height`              | `double`              | The height of the image in logical pixels.                                                                |
-| `fit`                 | `StacBoxFit`          | How the image should be inscribed into the space allocated during layout.                                 |
-| `repeat`              | `StacImageRepeat`     | How the image should be repeated if it doesn't fill its layout bounds.                                    |
-| `filterQuality`       | `StacFilterQuality`   | The quality level for image filtering operations.                                                         |
-| `semanticLabel`       | `String`              | A semantic description of the image for accessibility.                                                    |
-| `excludeFromSemantics`| `bool`                | Whether to exclude this image from semantics.                                                             |
+| Property              | Type                  | Description                                                                 |
+|-----------------------|-----------------------|-----------------------------------------------------------------------------|
+| `src`                 | `String`              | The source path or URL of the image to display.                             |
+| `alignment`           | `StacAlignment`       | How to align the image within its bounds.                                   |
+| `imageType`           | `StacImageType`       | The type of image source: `asset`, `network`, or `file`.                    |
+| `color`               | `StacColor`           | A color filter to apply to the image.                                       |
+| `width`               | `double`              | The width of the image in logical pixels.                                   |
+| `height`              | `double`              | The height of the image in logical pixels.                                  |
+| `fit`                 | `StacBoxFit`          | How the image should be inscribed into the space allocated during layout.   |
+| `repeat`              | `StacImageRepeat`     | How the image should be repeated if it doesn't fill its layout bounds.      |
+| `filterQuality`       | `StacFilterQuality`   | The quality level for image filtering operations.                           |
+| `semanticLabel`       | `String`              | A semantic description of the image for accessibility.                      |
+| `excludeFromSemantics`| `bool`                | Whether to exclude this image from semantics.                               |
 
-## Enum: StacImageType
+## Constructors
 
-| Value     | Description                                 |
-|-----------|---------------------------------------------|
-| `file`    | Load the image from a local file.           |
-| `network` | Load the image from a network URL.          |
-| `asset`   | Load the image from Flutter's asset bundle. |
+### StacImage.asset
 
-## Example
+Creates an image widget that loads from Flutter's asset bundle.
 
 <CodeGroup>
 ```dart Dart
-StacImage(
-  src: 'https://example.com/image.png',
-  alignment: StacAlignment.center,
-  imageType: StacImageType.network,
-  color: StacColors.white,
-  width: 200.0,
-  height: 100.0,
+const StacImage.asset(
+  'assets/logo.png',
+  width: 200,
+  height: 100,
+  fit: StacBoxFit.cover,
+)
+```
+
+```json JSON
+{
+  "type": "image",
+  "src": "assets/logo.png",
+  "imageType": "asset",
+  "width": 200,
+  "height": 100,
+  "fit": "cover"
+}
+```
+</CodeGroup>
+
+---
+
+### StacImage.network
+
+Creates an image widget that loads from a network URL.
+
+<CodeGroup>
+```dart Dart
+const StacImage.network(
+  'https://example.com/image.png',
+  width: 200,
+  height: 100,
   fit: StacBoxFit.contain,
 )
 ```
@@ -50,12 +71,63 @@ StacImage(
 {
   "type": "image",
   "src": "https://example.com/image.png",
-  "alignment": "center",
   "imageType": "network",
-  "color": "#FFFFFF",
-  "width": 200.0,
-  "height": 100.0,
+  "width": 200,
+  "height": 100,
   "fit": "contain"
+}
+```
+</CodeGroup>
+
+---
+
+### StacImage.file
+
+Creates an image widget that loads from a local file path.
+
+<CodeGroup>
+```dart Dart
+const StacImage.file(
+  '/path/to/image.png',
+  width: 200,
+  height: 100,
+)
+```
+
+```json JSON
+{
+  "type": "image",
+  "src": "/path/to/image.png",
+  "imageType": "file",
+  "width": 200,
+  "height": 100
+}
+```
+</CodeGroup>
+
+---
+
+### StacImage (Default)
+
+The default constructor allows you to specify any image source with the `imageType` property.
+
+<CodeGroup>
+```dart Dart
+const StacImage(
+  src: 'assets/logo.png',
+  width: 200,
+  height: 100,
+  fit: StacBoxFit.cover,
+)
+```
+
+```json JSON
+{
+  "type": "image",
+  "src": "assets/logo.png",
+  "width": 200,
+  "height": 100,
+  "fit": "cover"
 }
 ```
 </CodeGroup>

--- a/packages/stac_core/lib/widgets/image/stac_image.dart
+++ b/packages/stac_core/lib/widgets/image/stac_image.dart
@@ -51,6 +51,51 @@ class StacImage extends StacWidget {
     this.excludeFromSemantics,
   });
 
+  /// Creates an image widget that loads from application assets.
+  const StacImage.asset(
+    String path, {
+    this.alignment,
+    this.color,
+    this.width,
+    this.height,
+    this.fit,
+    this.repeat,
+    this.filterQuality,
+    this.semanticLabel,
+    this.excludeFromSemantics,
+  })  : src = path,
+        imageType = StacImageType.asset;
+
+  /// Creates an image widget that loads from a network URL.
+  const StacImage.network(
+    String url, {
+    this.alignment,
+    this.color,
+    this.width,
+    this.height,
+    this.fit,
+    this.repeat,
+    this.filterQuality,
+    this.semanticLabel,
+    this.excludeFromSemantics,
+  })  : src = url,
+        imageType = StacImageType.network;
+
+  /// Creates an image widget that loads from a local file path.
+  const StacImage.file(
+    String path, {
+    this.alignment,
+    this.color,
+    this.width,
+    this.height,
+    this.fit,
+    this.repeat,
+    this.filterQuality,
+    this.semanticLabel,
+    this.excludeFromSemantics,
+  })  : src = path,
+        imageType = StacImageType.file;
+
   /// The source path or URL of the image to display.
   final String src;
 

--- a/packages/stac_core/lib/widgets/image/stac_image.dart
+++ b/packages/stac_core/lib/widgets/image/stac_image.dart
@@ -63,8 +63,8 @@ class StacImage extends StacWidget {
     this.filterQuality,
     this.semanticLabel,
     this.excludeFromSemantics,
-  })  : src = path,
-        imageType = StacImageType.asset;
+  }) : src = path,
+       imageType = StacImageType.asset;
 
   /// Creates an image widget that loads from a network URL.
   const StacImage.network(
@@ -78,8 +78,8 @@ class StacImage extends StacWidget {
     this.filterQuality,
     this.semanticLabel,
     this.excludeFromSemantics,
-  })  : src = url,
-        imageType = StacImageType.network;
+  }) : src = url,
+       imageType = StacImageType.network;
 
   /// Creates an image widget that loads from a local file path.
   const StacImage.file(
@@ -93,8 +93,8 @@ class StacImage extends StacWidget {
     this.filterQuality,
     this.semanticLabel,
     this.excludeFromSemantics,
-  })  : src = path,
-        imageType = StacImageType.file;
+  }) : src = path,
+       imageType = StacImageType.file;
 
   /// The source path or URL of the image to display.
   final String src;


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

feat: add constructors for StacImage widget to support asset, network and file sources



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * StacImage now supports three simple ways to load images from asset, network, or file sources, making initialization easier across common use cases. Each option supports standard display controls (alignment, color, size, fit, repeat, filter quality) and accessibility settings for improved rendering and semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->