### PR TITLE
chore: release v1.3.0

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,6 +7,31 @@ This page documents the version history of Stac, including new features, breakin
 
 ---
 
+## 1.3.0
+
+### Refactor
+- Centralized cache configuration to `Stac.initialize` with `networkFirst` as the default cache strategy
+
+### New Features
+- Added DSL entry to documentation JSON
+- Added `stacSliverToBoxAdapter` widget, parser, example, and documentation
+- Added `stacSliverPadding` widget, parser, example, and documentation
+- Added `stacSliverSafeArea` widget, parser, example, and documentation
+- Added `stacSliverOpacity` widget, parser, example, and documentation
+- Added `stacSliverVisibility` widget, parser, example, and documentation
+- Added `stacSliverList` widget, parser, example, and documentation
+- Added `stacSliverFillRemaining` widget, parser, example, and documentation
+- Added `stacSliverGrid` widget, parser, example, and documentation
+- Enhanced `Positioned` widget with new constructors
+- Added constructors for `StacImage` widget to support asset, network, and file sources
+- Added StacNavigator API and navigation documentation
+
+### Documentation
+- Comprehensive documentation improvements with Dart examples
+- Added Dart code examples and wrapped all examples in a CodeGroup component for sliver widget documentation
+
+---
+
 ## 1.2.0
 
 ### New Features

--- a/examples/counter_example/pubspec.lock
+++ b/examples/counter_example/pubspec.lock
@@ -787,14 +787,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/examples/movie_app/pubspec.lock
+++ b/examples/movie_app/pubspec.lock
@@ -715,14 +715,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_core:
     dependency: "direct main"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/examples/stac_gallery/pubspec.lock
+++ b/examples/stac_gallery/pubspec.lock
@@ -787,14 +787,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_core:
     dependency: "direct main"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/packages/stac/CHANGELOG.md
+++ b/packages/stac/CHANGELOG.md
@@ -1,6 +1,21 @@
-## 1.3.0-dev.1
+## 1.3.0
 
 - **BREAKING**: Refactored caching to use global configuration via `Stac.initialize()`. See [Caching Docs](https://docs.stac.dev/concepts/caching) for migration guide.
+- refactor: Centralize cache configuration to `Stac.initialize` and set `networkFirst` as default cache strategy
+- feat: Add DSL entry to documentation JSON
+- feat: Add stacSliverToBoxAdapter widget, parser, example, and documentation
+- feat: Add stacSliverPadding widget, parser, example, and documentation
+- feat: Add stacSliverSafeArea widget, parser, example, and documentation
+- feat: Add stacSliverOpacity widget, parser, example, and documentation
+- feat: Add stacSliverVisibility widget, parser, example, and documentation
+- feat: Add stacSliverList widget, parser, example, and documentation
+- feat: Add stacSliverFillRemaining widget, parser, example, and documentation
+- feat: Add stacSliverGrid widget, parser, example, and documentation
+- feat: Enhance the Positioned widget with new constructors
+- feat: Add constructors for StacImage widget to support asset, network, and file sources
+- feat: StacNavigator API and navigation documentation
+- docs: Comprehensive documentation improvements with Dart examples
+- docs: Add Dart code examples and wrap all examples in a CodeGroup component for sliver widget documentation
 
 ## 1.2.0
 

--- a/packages/stac/pubspec.yaml
+++ b/packages/stac/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stac
 description: Stac is a Server-Driven UI (SDUI) framework for Flutter. Stac allows you to build beautiful cross-platform applications with JSON in real time.
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/StacDev/stac
 homepage: https://stac.dev/
 

--- a/packages/stac_core/CHANGELOG.md
+++ b/packages/stac_core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.0
+
+- Added `StacSliverToBoxAdapter` widget model
+- Added `StacSliverPadding` widget model
+- Added `StacSliverSafeArea` widget model
+- Added `StacSliverOpacity` widget model
+- Added `StacSliverVisibility` widget model
+- Added `StacSliverList` widget model
+- Added `StacSliverFillRemaining` widget model
+- Added `StacSliverGrid` widget model
+
 ## 1.2.0
 
 - Added `StacBadge` widget model for displaying badges with labels or counts

--- a/packages/stac_core/lib/widgets/sliver_opacity/stac_sliver_opacity.dart
+++ b/packages/stac_core/lib/widgets/sliver_opacity/stac_sliver_opacity.dart
@@ -2,6 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:stac_core/core/converters/double_converter.dart';
 import 'package:stac_core/core/stac_widget.dart';
 import 'package:stac_core/foundation/foundation.dart';
+
 part 'stac_sliver_opacity.g.dart';
 
 /// A Stac model representing Flutter's [SliverOpacity] widget.
@@ -64,6 +65,7 @@ class StacSliverOpacity extends StacWidget {
   @override
   String get type => WidgetType.sliverOpacity.name;
 
+  /// Creates a [StacSliverOpacity] from a JSON map.
   factory StacSliverOpacity.fromJson(Map<String, dynamic> json) =>
       _$StacSliverOpacityFromJson(json);
 

--- a/packages/stac_core/lib/widgets/sliver_visibility/stac_sliver_visibility.dart
+++ b/packages/stac_core/lib/widgets/sliver_visibility/stac_sliver_visibility.dart
@@ -84,6 +84,7 @@ class StacSliverVisibility extends StacWidget {
   @override
   String get type => WidgetType.sliverVisibility.name;
 
+  /// Creates a [StacSliverVisibility] from a JSON map.
   factory StacSliverVisibility.fromJson(Map<String, dynamic> json) =>
       _$StacSliverVisibilityFromJson(json);
 

--- a/packages/stac_core/pubspec.yaml
+++ b/packages/stac_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stac_core
 description: A pure Dart package that provides the core functionalities and common interfaces for the Stac server-driven UI framework.
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/StacDev/stac
 homepage: https://stac.dev/
 


### PR DESCRIPTION
## Release v1.3.0

Updates changelogs and bumps package versions for the 1.3.0 release.

### Changes
- **docs/changelog.mdx** – Add 1.3.0 section with refactor, new features, and documentation notes
- **packages/stac/CHANGELOG.md** – Add 1.3.0 release notes (replacing 1.3.0-dev.1)
- **packages/stac/pubspec.yaml** – Bump version 1.2.0 → 1.3.0
- **packages/stac_core/CHANGELOG.md** – Add 1.3.0 with new sliver widget models
- **packages/stac_core/pubspec.yaml** – Bump version 1.2.0 → 1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added eight sliver widgets (ToBoxAdapter, Padding, SafeArea, Opacity, Visibility, List, FillRemaining, Grid)
  * Enhanced Positioned constructors
  * StacImage supports asset, network, and file sources
  * Introduced StacNavigator API with enhanced navigation capabilities

* **Refactor**
  * Centralized cache configuration with networkFirst as the default

* **Documentation**
  * Expanded docs with Dart examples and improved sliver widget guides

* **Chores**
  * Bumped package versions to 1.3.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->