### PR TITLE
fix(stac_cli): remove snake case conversion

### DIFF
--- a/packages/stac_cli/lib/src/services/build_service.dart
+++ b/packages/stac_cli/lib/src/services/build_service.dart
@@ -494,7 +494,7 @@ Future<void> main(List<String> args) async {
         final cleaned = _cleanJson(json);
         if (cleaned == null) continue;
 
-        final fileName = StringUtils.toSnakeCase(artifact.artifactName);
+        final fileName = artifact.artifactName;
         final outputFilePath = path.join(outputDir, '$fileName.json');
         final jsonString = const JsonEncoder.withIndent('  ').convert(cleaned);
         await FileUtils.writeFile(outputFilePath, jsonString);

--- a/packages/stac_cli/lib/src/utils/string_utils.dart
+++ b/packages/stac_cli/lib/src/utils/string_utils.dart
@@ -19,14 +19,4 @@ class StringUtils {
         .replaceAll('Â½', '½') // Fix fraction encoding issues
         .replaceAll('Â¾', '¾'); // Fix fraction encoding issues
   }
-
-  /// Converts a camelCase/PascalCase string to snake_case.
-  static String toSnakeCase(String value) {
-    return value
-        .replaceAllMapped(
-          RegExp(r'[A-Z]'),
-          (match) => '_${match.group(0)!.toLowerCase()}',
-        )
-        .replaceFirst(RegExp(r'^_'), '');
-  }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Removed the automatic conversion of artifact names to snake_case when generating JSON files with `stac build`.  
`BuildService._processArtifacts` now uses the user-provided `artifact.artifactName` directly as the base for the output JSON filename, ensuring the generated `screens` and `themes` JSON files exactly match the names specified in `@StacScreen` / `@StacThemeRef` annotations.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JSON artifact file naming: generated files now use artifact names directly instead of applying an automatic format conversion, yielding more predictable filenames that match your asset identifiers.
  * Note: This changes output filenames compared to the previous converted format—expect different file names for existing artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->