### PR TITLE
feat(deploy_service): add console URL logging for successful deployments

### DIFF
--- a/packages/stac_cli/lib/src/services/deploy_service.dart
+++ b/packages/stac_cli/lib/src/services/deploy_service.dart
@@ -118,6 +118,13 @@ class DeployService {
     ConsoleLogger.info(
       'Screens → success: $screenSuccess, failed: $screenFail | Themes → success: $themeSuccess, failed: $themeFail',
     );
+
+    if (totalFailures == 0) {
+      final consoleUrl = 'https://console.stac.dev/project/$projectId';
+      ConsoleLogger.info(
+        'Open your project in the Stac Console to inspect your screens and themes: $consoleUrl',
+      );
+    }
   }
 
   /// Upload a single screen JSON to Cloud Functions API


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Updated `stac deploy` to print a project-specific Stac Console URL after the deployment summary, using the resolved `projectId`, making it easy for users to jump directly to their project dashboard (for example `https://console.stac.dev/project/sEsdfWgfRaG`).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now receive a console URL displayed after successful deployments, guiding them to inspect their project in Stac Console for monitoring and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->