### PR TITLE
chore: Prepare stac 1.5.0 release

### DIFF
--- a/examples/counter_example/pubspec.lock
+++ b/examples/counter_example/pubspec.lock
@@ -795,14 +795,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/examples/counter_example/pubspec.lock
+++ b/examples/counter_example/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -869,10 +869,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   timing:
     dependency: transitive
     description:
@@ -994,5 +994,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/examples/movie_app/pubspec.lock
+++ b/examples/movie_app/pubspec.lock
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -797,10 +797,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -914,5 +914,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/examples/movie_app/pubspec.lock
+++ b/examples/movie_app/pubspec.lock
@@ -723,14 +723,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/examples/stac_gallery/pubspec.lock
+++ b/examples/stac_gallery/pubspec.lock
@@ -787,14 +787,14 @@ packages:
       path: "../../packages/stac"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/stac_core"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_framework:
     dependency: "direct overridden"
     description:

--- a/examples/stac_gallery/pubspec.lock
+++ b/examples/stac_gallery/pubspec.lock
@@ -452,10 +452,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -868,10 +868,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -1025,5 +1025,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/packages/stac/CHANGELOG.md
+++ b/packages/stac/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.5.0
+
+- feat: add Material 3 navigation bar, navigation view, and generic navigation controller parsers.
+- feat: use `flutter_validators` for form validation rules with parameterized validator options.
+- feat: add mask input formatter support.
+- feat: add text decoration line parsing for text styles.
+- feat: add floating label behavior parsing for input decoration.
+- fix: use `DropdownMenuEntry<Object>` for safer dropdown menu parsing.
+
 ## 1.4.0
 
 - feat: enhance input decoration with new border options.

--- a/packages/stac/pubspec.yaml
+++ b/packages/stac/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stac
 description: Stac is a Server-Driven UI (SDUI) framework for Flutter. Stac allows you to build beautiful cross-platform applications with JSON in real time.
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/StacDev/stac
 homepage: https://stac.dev/
 
@@ -24,7 +24,7 @@ dependencies:
   cached_network_image: ^3.4.1
   flutter_svg: ^2.2.3
   stac_logger: ^1.1.0
-  stac_core: ^1.4.0
+  stac_core: ^1.5.0
   shared_preferences: ^2.5.4
 
 dev_dependencies:

--- a/packages/stac_cli/pubspec.lock
+++ b/packages/stac_cli/pubspec.lock
@@ -495,7 +495,7 @@ packages:
       path: "../stac_core"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   stac_logger:
     dependency: "direct overridden"
     description:

--- a/packages/stac_core/CHANGELOG.md
+++ b/packages/stac_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.5.0
+
+- Added `StacDefaultNavigationController`, `StacNavigationBar`, `StacNavigationView`, and `StacNavigationDestination` models for Material 3 navigation.
+- Added `mask` input formatter support.
+- Added validator `options` for parameterized form validation rules.
+- Added text decoration line support to `StacTextStyle`.
+- Added `floatingLabelBehavior` support to `StacInputDecoration`.
+
 ## 1.4.0
   - Added new border option models for input decoration (`StacInputBorder`, etc).
   - Added `copyWith` method to `StacThemeTextStyle` model.

--- a/packages/stac_core/pubspec.yaml
+++ b/packages/stac_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stac_core
 description: A pure Dart package that provides the core functionalities and common interfaces for the Stac server-driven UI framework.
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/StacDev/stac
 homepage: https://stac.dev/
 


### PR DESCRIPTION
## Summary

Prepares the `stac_core` and `stac` packages for a `1.5.0` release.

## Changes

- Bump `stac_core` from `1.4.0` to `1.5.0`.
- Bump `stac` from `1.4.0` to `1.5.0`.
- Update `stac` to depend on `stac_core ^1.5.0`.
- Add package changelog entries for the release-relevant changes.

## Release Notes

- Publish `stac_core` first.
- Publish `stac` after `stac_core 1.5.0` is available on pub.dev.

## Validation

- `dart analyze .` in `packages/stac_core`
- `flutter analyze .` in `packages/stac`
- `flutter test` in `packages/stac`
- `git diff --check`
- `git diff --cached --check`

`dart test` in `packages/stac_core` found no tests. Publish dry-runs reached pub validation, then reported expected local release-state warnings because the release files were modified and local `pubspec_overrides.yaml` files were active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Material 3 navigation components for app navigation
  * Introduced parameterized form validation options for flexible rule configuration
  * Added input mask/formatter support for controlled text input
  * Enhanced text styling with text decoration line options
  * Added floating label behavior support for input fields
  * Improved dropdown component parsing safety

* **Chores**
  * Version bumped to 1.5.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/StacDev/stac/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->