### PR TITLE
docs: update README to use correct banner image URL

### DIFF
--- a/packages/stac/README.md
+++ b/packages/stac/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img src="https://raw.githubusercontent.com/StacDev/stac/refs/heads/dev/assets/stac_banner.png" width="100%" alt="Stac: Server-Driven UI Framework for Flutter" />
+  <img src="https://raw.githubusercontent.com/StacDev/stac/refs/heads/main/assets/stac_banner.png" width="100%" alt="Stac: Server-Driven UI Framework for Flutter" />
 </p>
 
 <p align="center">


### PR DESCRIPTION

## Description

Updates the image URL in the stac package README to reference the stable main branch instead of the dev branch, ensuring the banner image loads correctly for all users.

## Related Issues

Closes #486 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README banner image to use the `main` branch, ensuring the displayed image remains available in the primary release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->