### PR TITLE
chore: quiet analyzer noise and await cache/upgrade futures

### DIFF
--- a/examples/counter_example/analysis_options.yaml
+++ b/examples/counter_example/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/examples/counter_example/pubspec.lock
+++ b/examples/counter_example/pubspec.lock
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -869,10 +869,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timing:
     dependency: transitive
     description:
@@ -925,10 +925,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -994,5 +994,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/examples/movie_app/analysis_options.yaml
+++ b/examples/movie_app/analysis_options.yaml
@@ -7,6 +7,15 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/examples/movie_app/pubspec.lock
+++ b/examples/movie_app/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -412,10 +412,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -797,10 +797,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -845,10 +845,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -914,5 +914,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.35.0"

--- a/examples/movie_app/stac/home_screen.dart
+++ b/examples/movie_app/stac/home_screen.dart
@@ -4,11 +4,11 @@ import 'package:stac/stac_core.dart';
 
 @StacScreen(screenName: 'home_screen')
 StacWidget homeScreen() {
-  return StacDefaultBottomNavigationController(
+  return StacDefaultNavigationController(
     length: 3,
     child: StacScaffold(
       extendBodyBehindAppBar: true,
-      body: StacBottomNavigationView(
+      body: StacNavigationView(
         children: [
           StacListView(
             padding: StacEdgeInsets.all(0),

--- a/packages/stac/analysis_options.yaml
+++ b/packages/stac/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
   exclude:
     - lib/**.g.dart
     - lib/**.freezed.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/stac/lib/src/services/stac_cache_service.dart
+++ b/packages/stac/lib/src/services/stac_cache_service.dart
@@ -1,6 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:stac/src/models/stac_cache.dart';
 import 'package:stac/src/models/stac_artifact_type.dart';
+import 'package:stac/src/models/stac_cache.dart';
 import 'package:stac_logger/stac_logger.dart';
 
 /// Service for managing cached Stac artifacts (screens, themes, etc.).
@@ -75,7 +75,7 @@ class StacCacheService {
         cachedAt: DateTime.now(),
       );
 
-      return prefs.setString(cacheKey, artifactCache.toJsonString());
+      return await prefs.setString(cacheKey, artifactCache.toJsonString());
     } catch (e) {
       return false;
     }
@@ -90,7 +90,7 @@ class StacCacheService {
       final prefs = await _sharedPrefs;
       final cachePrefix = _getCachePrefix(artifactType);
       final cacheKey = '$cachePrefix$artifactName';
-      return prefs.remove(cacheKey);
+      return await prefs.remove(cacheKey);
     } catch (e) {
       return false;
     }

--- a/packages/stac_cli/lib/src/exceptions/build_exception.dart
+++ b/packages/stac_cli/lib/src/exceptions/build_exception.dart
@@ -7,8 +7,8 @@ class BuildException extends StacException {
 
 /// Exception thrown when Dart to JSON conversion fails
 class ConversionException extends BuildException {
-  const ConversionException(String message, {dynamic cause})
-    : super('Dart to JSON conversion failed: $message', cause: cause);
+  const ConversionException(String message, {super.cause})
+    : super('Dart to JSON conversion failed: $message');
 }
 
 /// Exception thrown when SDUI validation fails

--- a/packages/stac_cli/lib/src/services/upgrade_service.dart
+++ b/packages/stac_cli/lib/src/services/upgrade_service.dart
@@ -372,7 +372,7 @@ class UpgradeService {
           await response.drain<void>();
           final nextUri = uri.resolve(redirectUrl);
           _validateDownloadUri(nextUri);
-          return _downloadFile(nextUri.toString(), destPath);
+          return await _downloadFile(nextUri.toString(), destPath);
         }
       }
 

--- a/packages/stac_framework/analysis_options.yaml
+++ b/packages/stac_framework/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at

--- a/packages/stac_webview/analysis_options.yaml
+++ b/packages/stac_webview/analysis_options.yaml
@@ -4,3 +4,10 @@ analyzer:
   exclude:
     - lib/**.g.dart
     - lib/**.freezed.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/stac_playground/analysis_options.yaml
+++ b/stac_playground/analysis_options.yaml
@@ -14,6 +14,12 @@ analyzer:
     # `lib/dsl` ships as an asset bundle, so Flutter copies every example into
     # build/. Without this, `dart analyze .` reports each one several times over.
     - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/stac_playground/pubspec.lock
+++ b/stac_playground/pubspec.lock
@@ -292,10 +292,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -652,10 +652,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -764,10 +764,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

Keeps `dart analyze` from walking generated platform trees, migrates the movie app off the deprecated navigation widgets, and awaits SharedPreferences / CLI download futures so failures land in the existing `try/catch` paths instead of escaping as unhandled async errors.

Also refreshes example and playground lockfiles for the current Flutter/Dart SDK (matcher, meta, test_api, vector_math).

## Related Issues

N/A

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore

## Test plan

- [ ] Run `melos analyze` and confirm no new issues from generated `android`/`ios`/`web` trees
- [ ] Open movie app home screen and confirm the 3-tab bottom nav still switches views
- [ ] Confirm cache save/remove still returns `false` on SharedPreferences failure instead of throwing
- [ ] (Optional) `stac upgrade` follows a redirect and completes the download