### PR TITLE
fix: map scroll cacheExtent to Flutter 3.41 ScrollCacheExtent

### DIFF
--- a/packages/stac/lib/src/parsers/widgets/stac_custom_scroll_view/stac_custom_scroll_view_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_custom_scroll_view/stac_custom_scroll_view_parser.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/interaction/stac_drag_start_behavior_parser.dart';
 import 'package:stac/src/parsers/foundation/interaction/stac_hit_test_behavior_parser.dart';
@@ -32,7 +33,9 @@ class StacCustomScrollViewParser extends StacParser<StacCustomScrollView> {
       physics: model.physics?.parse,
       shrinkWrap: model.shrinkWrap ?? false,
       anchor: model.anchor ?? 0.0,
-      cacheExtent: model.cacheExtent,
+      scrollCacheExtent: model.cacheExtent == null
+          ? null
+          : ScrollCacheExtent.pixels(model.cacheExtent!),
       semanticChildCount: model.semanticChildCount,
       dragStartBehavior:
           (model.dragStartBehavior ?? StacDragStartBehavior.start).parse,

--- a/packages/stac/lib/src/parsers/widgets/stac_grid_view/stac_grid_view_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_grid_view/stac_grid_view_parser.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/geometry/stac_edge_insets_parser.dart';
 import 'package:stac/src/parsers/foundation/interaction/stac_drag_start_behavior_parser.dart';
@@ -39,7 +40,9 @@ class StacGridViewParser extends StacParser<StacGridView> {
       addAutomaticKeepAlives: model.addAutomaticKeepAlives ?? true,
       addRepaintBoundaries: model.addRepaintBoundaries ?? true,
       addSemanticIndexes: model.addSemanticIndexes ?? true,
-      cacheExtent: model.cacheExtent,
+      scrollCacheExtent: model.cacheExtent == null
+          ? null
+          : ScrollCacheExtent.pixels(model.cacheExtent!),
       itemBuilder: (context, index) {
         final List<Widget>? parsed = model.children?.parseList(context);
         if (parsed == null || index >= parsed.length) {

--- a/packages/stac/lib/src/parsers/widgets/stac_list_view/stac_list_view_parser.dart
+++ b/packages/stac/lib/src/parsers/widgets/stac_list_view/stac_list_view_parser.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:stac/src/parsers/core/stac_widget_parser.dart';
 import 'package:stac/src/parsers/foundation/geometry/stac_edge_insets_parser.dart';
 import 'package:stac/src/parsers/foundation/interaction/stac_drag_start_behavior_parser.dart';
@@ -35,7 +36,9 @@ class StacListViewParser extends StacParser<StacListView> {
       addAutomaticKeepAlives: model.addAutomaticKeepAlives ?? true,
       addRepaintBoundaries: model.addRepaintBoundaries ?? true,
       addSemanticIndexes: model.addSemanticIndexes ?? true,
-      cacheExtent: model.cacheExtent,
+      scrollCacheExtent: model.cacheExtent == null
+          ? null
+          : ScrollCacheExtent.pixels(model.cacheExtent!),
       dragStartBehavior:
           model.dragStartBehavior?.parse ?? DragStartBehavior.start,
       keyboardDismissBehavior:


### PR DESCRIPTION
## Summary
- Flutter 3.41 deprecated `ScrollView.cacheExtent` in favor of `scrollCacheExtent`.
- ListView, GridView, and CustomScrollView parsers now wrap the existing Stac `cacheExtent` double as `ScrollCacheExtent.pixels`, so JSON/DSL stay unchanged.

## Description

Flutter 3.41 deprecated `ScrollView.cacheExtent` in favor of `scrollCacheExtent`. The ListView, GridView, and CustomScrollView parsers now wrap the existing Stac `cacheExtent` double as `ScrollCacheExtent.pixels`, so JSON/DSL stay unchanged.

## Related Issues

N/A

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore

## Test plan
- [ ] `dart analyze` on `packages/stac` no longer reports the `cacheExtent` deprecation
- [ ] ListView / GridView / CustomScrollView with `cacheExtent` still cache the same pixel extent
- [ ] Omitting `cacheExtent` still uses Flutter's default cache behavior

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache extent handling for custom scroll, grid, and list views.
  - Configured cache extents using pixel-based values when specified, while preserving default behavior when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->